### PR TITLE
Migrate benchmark command from as benchmark-url

### DIFF
--- a/cli/commands/benchmark-url.mjs
+++ b/cli/commands/benchmark-url.mjs
@@ -1,0 +1,259 @@
+/**
+ * CLI command to benchmark several URLs for TTFB and Server-Timing metrics.
+ *
+ * WPP Research, Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * External dependencies
+ */
+import fs from 'fs';
+import readline from 'readline';
+import autocannon from 'autocannon';
+import round from 'lodash-es/round.js';
+
+/**
+ * Internal dependencies
+ */
+import {
+   log,
+   formats,
+   table,
+   isValidTableFormat,
+   OUTPUT_FORMAT_TABLE,
+} from '../lib/cli/logger.mjs';
+import { calcMedian } from '../lib/util/math.mjs';
+
+export const options = [
+	{
+		argname: '-u, --url <url>',
+		description: 'An URL to run benchmark tests for',
+	},
+	{
+		argname: '-c, --concurrency <concurrency>',
+		description: 'Number of multiple requests to make at a time',
+		defaults: 1,
+	},
+	{
+		argname: '-n, --number <number>',
+		description: 'Number of requests to perform',
+		defaults: 1,
+	},
+	{
+		argname: '-f, --file <file>',
+		description: 'File with URLs to run benchmark tests for',
+	},
+	{
+		argname: '-o, --output <output>',
+		description: 'Output format: csv or table',
+		defaults: OUTPUT_FORMAT_TABLE,
+	},
+];
+
+export async function handler( opt ) {
+	if ( ! isValidTableFormat( opt.output ) ) {
+		log(
+			formats.error(
+				'The output format provided via the --output (-o) argument must be either "table" or "csv".'
+			)
+		);
+		return;
+	}
+
+	const { concurrency: connections, number: amount } = opt;
+	const results = [];
+
+	for await ( const url of getURLs( opt ) ) {
+		const { completeRequests, responseTimes, metrics } = await benchmarkURL(
+			{
+				url,
+				connections,
+				amount,
+			}
+		);
+
+		results.push( [ url, completeRequests, responseTimes, metrics ] );
+	}
+
+	if ( results.length === 0 ) {
+		log(
+			formats.error(
+				'You need to provide a URL to benchmark via the --url (-u) argument, or a file with multiple URLs via the --file (-f) argument.'
+			)
+		);
+	} else {
+		outputResults( opt, results );
+	}
+};
+
+/**
+ * Generates URLs to benchmark based on command arguments. If both "<url>" and "<file>" arguments
+ * are passed to the command, then both will be used to generate URLs.
+ *
+ * @param {BenchmarkCommandOptions} opt Command options.
+ */
+async function* getURLs( opt ) {
+	if ( !! opt.url ) {
+		yield opt.url;
+	}
+
+	if ( !! opt.file ) {
+		const rl = readline.createInterface( {
+			input: fs.createReadStream( opt.file ),
+			crlfDelay: Infinity,
+		} );
+
+		for await ( const url of rl ) {
+			if ( url.length > 0 ) {
+				yield url;
+			}
+		}
+	}
+}
+
+/**
+ * Benchmarks an URL and returns response time and server-timing metrics for every request.
+ *
+ * @param {BenchmarkOptions} params Benchmark parameters.
+ * @return {BenchmarkResults} Response times and metrics arrays.
+ */
+function benchmarkURL( params ) {
+	const metrics = {};
+	const responseTimes = [];
+	let completeRequests = 0;
+
+	const onHeaders = ( { headers } ) => {
+		const responseMetrics = getServerTimingMetricsFromHeaders( headers );
+		Object.entries( responseMetrics ).forEach( ( [ key, value ] ) => {
+			metrics[ key ] = metrics[ key ] || [];
+			metrics[ key ].push( +value );
+		} );
+	};
+
+	const onResponse = ( statusCode, resBytes, responseTime ) => {
+		if ( statusCode === 200 ) {
+			completeRequests++;
+		}
+
+		responseTimes.push( responseTime );
+	};
+
+	const instance = autocannon( {
+		method: 'POST', // The post method is needed to bypass CDN or full page cache.
+		...params,
+		setupClient( client ) {
+			client.on( 'headers', onHeaders );
+			client.on( 'response', onResponse );
+		},
+	} );
+
+	const onStop = instance.stop.bind( instance );
+	process.once( 'SIGINT', onStop );
+
+	return new Promise( ( resolve ) => {
+		instance.on( 'done', () => {
+			process.off( 'SIGINT', onStop );
+			resolve( { responseTimes, completeRequests, metrics } );
+		} );
+	} );
+}
+
+/**
+ * Reads the Server-Timing metrics from the response headers.
+ *
+ * @param {Array.<string>} headers Array of response headers information where each even element is a header name and an odd element is the header value.
+ * @return {Object} An object where keys are metric names and values are metric values.
+ */
+function getServerTimingMetricsFromHeaders( headers ) {
+	for ( let i = 0, len = headers.length; i < len; i += 2 ) {
+		if ( headers[ i ].toLowerCase() !== 'server-timing' ) {
+			continue;
+		}
+
+		return headers[ i + 1 ]
+			.split( ',' )
+			.map( ( timing ) => timing.trim().split( ';dur=' ) )
+			.reduce(
+				( obj, [ key, value ] ) => ( { ...obj, [ key ]: value } ),
+				{}
+			);
+	}
+
+	return {};
+}
+
+/**
+ * Ouptuts results of benchmarking.
+ *
+ * @param {BenchmarkCommandOptions} opt     Command options.
+ * @param {Array.<Array>}           results A collection of benchmark results for each URL.
+ */
+function outputResults( opt, results ) {
+	const len = results.length;
+	const allMetricNames = {};
+
+	for ( let i = 0; i < len; i++ ) {
+		for ( const metric of Object.keys( results[ i ][ 3 ] ) ) {
+			allMetricNames[ metric ] = '';
+		}
+	}
+
+	const newRow = ( title ) => {
+		const line = new Array( len + 1 ).fill( '' );
+		line[ 0 ] = title;
+		return line;
+	};
+
+	const headings = [
+		'',
+		'Success Rate',
+		'Response Time',
+	];
+
+	Object.keys( allMetricNames ).forEach( ( name ) => {
+		headings.push( name );
+	} );
+
+	const tableData = [];
+	for ( let i = 0; i < len; i++ ) {
+		const [ url, completeRequests, responseTimes, metrics ] = results[ i ];
+		const completionRate = round(
+			( 100 * completeRequests ) / ( opt.number || 1 ),
+			1
+		);
+
+		const tableRow = [
+			url,
+			`${ completionRate }%`,
+			round( calcMedian( responseTimes ), 2 ),
+		];
+
+		for ( const metric of Object.keys( metrics ) ) {
+			const metricAvgMs = round( calcMedian( metrics[ metric ] ), 2 );
+			tableRow.push( metricAvgMs );
+		}
+
+		tableData.push( tableRow );
+	}
+
+	log(
+		table(
+			headings,
+			tableData,
+			opt.output,
+			true
+		)
+	);
+}

--- a/cli/run.mjs
+++ b/cli/run.mjs
@@ -30,6 +30,10 @@ import {
 	formats,
 } from './lib/cli/logger.mjs';
 import {
+	handler as benchmarkUrlHandler,
+	options as benchmarkUrlOptions,
+} from './commands/benchmark-url.mjs';
+import {
 	handler as wptMetricsHandler,
 	options as wptMetricsOptions,
 } from './commands/wpt-metrics.mjs';
@@ -62,6 +66,9 @@ const catchException = ( handler ) => {
 	};
 };
 
+withOptions( program.command( 'benchmark-url' ), benchmarkUrlOptions )
+	.description( 'Runs benchmarks for an URL' )
+	.action( catchException( benchmarkUrlHandler ) );
 withOptions( program.command( 'wpt-metrics' ), wptMetricsOptions )
 	.description( 'Gets performance metrics for a WebPageTest result' )
 	.action( catchException( wptMetricsHandler ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,12 @@
         "@jridgewell/trace-mapping": "^0.3.9"
       }
     },
+    "@assemblyscript/loader": {
+      "version": "0.19.23",
+      "resolved": "https://registry.npmjs.org/@assemblyscript/loader/-/loader-0.19.23.tgz",
+      "integrity": "sha512-ulkCYfFbYj01ie1MDOyxv2F6SpRN1TOj7fQxbP07D6HmeR+gr2JLSmINKjga2emB+b1L2KGrFKBTc+e00p54nw==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
@@ -1286,6 +1292,13 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
+    },
+    "@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "dev": true,
+      "optional": true
     },
     "@csstools/selector-specificity": {
       "version": "2.0.2",
@@ -3256,6 +3269,59 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
       "dev": true
     },
+    "autocannon": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/autocannon/-/autocannon-7.10.0.tgz",
+      "integrity": "sha512-PY1UrXL4NHE7J0hA6GGN2r8xjiAePS/bii3Hz7NOvp4JO3xDNBgRftDjfAxj1t6FDWXiXEOuKF/pdDiisIS8ZA==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "char-spinner": "^1.0.1",
+        "cli-table3": "^0.6.0",
+        "color-support": "^1.1.1",
+        "cross-argv": "^2.0.0",
+        "form-data": "^4.0.0",
+        "has-async-hooks": "^1.0.0",
+        "hdr-histogram-js": "^3.0.0",
+        "hdr-histogram-percentiles-obj": "^3.0.0",
+        "http-parser-js": "^0.5.2",
+        "hyperid": "^3.0.0",
+        "lodash.chunk": "^4.2.0",
+        "lodash.clonedeep": "^4.5.0",
+        "lodash.flatten": "^4.4.0",
+        "manage-path": "^2.0.0",
+        "on-net-listen": "^1.1.1",
+        "pretty-bytes": "^5.4.1",
+        "progress": "^2.0.3",
+        "reinterval": "^1.1.0",
+        "retimer": "^3.0.0",
+        "semver": "^7.3.2",
+        "subarg": "^1.0.0",
+        "timestring": "^6.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "dev": true,
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        },
+        "semver": {
+          "version": "7.3.8",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+          "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
+          "dev": true,
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        }
+      }
+    },
     "autoprefixer": {
       "version": "10.4.13",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.13.tgz",
@@ -3750,6 +3816,12 @@
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
       "dev": true
     },
+    "char-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/char-spinner/-/char-spinner-1.0.1.tgz",
+      "integrity": "sha512-acv43vqJ0+N0rD+Uw3pDHSxP30FHrywu2NO6/wBaHChJIizpDeBUd6NjqhNhy9LGaEAhZAXn46QzmlAvIWd16g==",
+      "dev": true
+    },
     "check-node-version": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/check-node-version/-/check-node-version-4.2.1.tgz",
@@ -3865,6 +3937,16 @@
         "del": "^4.1.1"
       }
     },
+    "cli-table3": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.3.tgz",
+      "integrity": "sha512-w5Jac5SykAeZJKntOxJCrm63Eg5/4dhMWIcuTbo9rpE+brgaSZo0RuNJZeOyMgsUdhDeojvgyQLmjI+K50ZGyg==",
+      "dev": true,
+      "requires": {
+        "@colors/colors": "1.5.0",
+        "string-width": "^4.2.0"
+      }
+    },
     "cliui": {
       "version": "7.0.4",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
@@ -3925,6 +4007,12 @@
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
       "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+      "dev": true
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
       "dev": true
     },
     "colord": {
@@ -4204,6 +4292,12 @@
         "path-type": "^4.0.0",
         "yaml": "^1.10.0"
       }
+    },
+    "cross-argv": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/cross-argv/-/cross-argv-2.0.0.tgz",
+      "integrity": "sha512-YIaY9TR5Nxeb8SMdtrU8asWVM4jqJDNDYlKV21LxtYcfNJhp1kEsgSa6qXwXgzN0WQWGODps0+TlGp2xQSHwOg==",
+      "dev": true
     },
     "cross-fetch": {
       "version": "3.1.5",
@@ -6188,6 +6282,12 @@
         "function-bind": "^1.1.1"
       }
     },
+    "has-async-hooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/has-async-hooks/-/has-async-hooks-1.0.0.tgz",
+      "integrity": "sha512-YF0VPGjkxr7AyyQQNykX8zK4PvtEDsUJAPqwu06UFz1lb6EvI53sPh5H1kWxg8NXI5LsfRCZ8uX9NkYDZBb/mw==",
+      "dev": true
+    },
     "has-bigints": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.0.2.tgz",
@@ -6223,6 +6323,23 @@
       "requires": {
         "has-symbols": "^1.0.2"
       }
+    },
+    "hdr-histogram-js": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-js/-/hdr-histogram-js-3.0.0.tgz",
+      "integrity": "sha512-/EpvQI2/Z98mNFYEnlqJ8Ogful8OpArLG/6Tf2bPnkutBVLIeMVNHjk1ZDfshF2BUweipzbk+dB1hgSB7SIakw==",
+      "dev": true,
+      "requires": {
+        "@assemblyscript/loader": "^0.19.21",
+        "base64-js": "^1.2.0",
+        "pako": "^1.0.3"
+      }
+    },
+    "hdr-histogram-percentiles-obj": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hdr-histogram-percentiles-obj/-/hdr-histogram-percentiles-obj-3.0.0.tgz",
+      "integrity": "sha512-7kIufnBqdsBGcSZLPJwqHT3yhk1QTsSlFsVD3kx5ixH/AlgBs9yM1q6DPhXZ8f8gtdqgh7N7/5btRLpQsS2gHw==",
+      "dev": true
     },
     "header-case": {
       "version": "2.0.4",
@@ -6395,6 +6512,16 @@
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
       "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
       "dev": true
+    },
+    "hyperid": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/hyperid/-/hyperid-3.0.1.tgz",
+      "integrity": "sha512-I+tl7TS5nsoVhkxqX1rS3Qmqlq44eoPUcgPthW8v3IW8CvWL7lwtd6HQbkDUMrBKJTG0vgEaRsjT35imW/D+9Q==",
+      "dev": true,
+      "requires": {
+        "uuid": "^8.3.2",
+        "uuid-parse": "^1.1.0"
+      }
     },
     "iconv-lite": {
       "version": "0.4.24",
@@ -7623,10 +7750,34 @@
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "dev": true
     },
+    "lodash-es": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "dev": true
+    },
+    "lodash.chunk": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
+      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
+      "dev": true
+    },
+    "lodash.clonedeep": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
+      "integrity": "sha512-H5ZhCF25riFd9uB5UCkVKo61m3S/xZk1x4wA6yp/L3RFP6Z/eHH1ymQcGLo7J3GMPfm0V/7m1tryHuGVxpqEBQ==",
+      "dev": true
+    },
     "lodash.debounce": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
+      "dev": true
+    },
+    "lodash.flatten": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.flatten/-/lodash.flatten-4.4.0.tgz",
+      "integrity": "sha512-C5N2Z3DgnnKr0LOpv/hKCgKdb7ZZwafIrsesve6lmzvZIRZRGaZ/l6Q8+2W7NaT+ZwO3fFlSCzCzrDCFdJfZ4g==",
       "dev": true
     },
     "lodash.memoize": {
@@ -7707,6 +7858,12 @@
       "requires": {
         "tmpl": "1.0.5"
       }
+    },
+    "manage-path": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/manage-path/-/manage-path-2.0.0.tgz",
+      "integrity": "sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==",
+      "dev": true
     },
     "map-obj": {
       "version": "4.3.0",
@@ -8406,6 +8563,12 @@
       "integrity": "sha512-pZAE+FJLoyITytdqK0U5s+FIpjN0JP3OzFi/u8Rx+EV5/W+JTWGXG8xFzevE7AjBfDqHv/8vL8qQsIhHnqRkrA==",
       "dev": true
     },
+    "on-net-listen": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/on-net-listen/-/on-net-listen-1.1.2.tgz",
+      "integrity": "sha512-y1HRYy8s/RlcBvDUwKXSmkODMdx4KSuIvloCnQYJ2LdBBC1asY4HtfhXwe3UWknLakATZDnbzht2Ijw3M1EqFg==",
+      "dev": true
+    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -8499,6 +8662,12 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
+      "dev": true
+    },
+    "pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
       "dev": true
     },
     "param-case": {
@@ -9089,6 +9258,12 @@
         "fast-diff": "^1.1.2"
       }
     },
+    "pretty-bytes": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
+      "integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
+      "dev": true
+    },
     "pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
@@ -9536,6 +9711,12 @@
         }
       }
     },
+    "reinterval": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reinterval/-/reinterval-1.1.0.tgz",
+      "integrity": "sha512-QIRet3SYrGp0HUHO88jVskiG6seqUGC5iAG7AwI/BV4ypGcuqk9Du6YQBUOUqm9c8pw1eyLoIaONifRua1lsEQ==",
+      "dev": true
+    },
     "require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -9617,6 +9798,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/resolve.exports/-/resolve.exports-1.1.0.tgz",
       "integrity": "sha512-J1l+Zxxp4XK3LUDZ9m60LRJF/mAe4z6a4xyabPHk7pvK5t35dACV32iIjJDFeWZFfZlO29w6SZ67knR0tHzJtQ==",
+      "dev": true
+    },
+    "retimer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/retimer/-/retimer-3.0.0.tgz",
+      "integrity": "sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==",
       "dev": true
     },
     "retry": {
@@ -10549,6 +10736,15 @@
         "postcss-value-parser": "^4.1.0"
       }
     },
+    "subarg": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
+      "integrity": "sha512-RIrIdRY0X1xojthNcVtgT9sjpOGagEUKpZdgBUi054OEPFo282yg+zE+t1Rj3+RqKq2xStL7uUHhY+AjbC4BXg==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.1.0"
+      }
+    },
     "supports-color": {
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -10772,6 +10968,12 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
       "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "dev": true
+    },
+    "timestring": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/timestring/-/timestring-6.0.0.tgz",
+      "integrity": "sha512-wMctrWD2HZZLuIlchlkE2dfXJh7J2KDI9Dwl+2abPYg0mswQHfOAyQW3jJg1pY5VfttSINZuKcXoB3FGypVklA==",
       "dev": true
     },
     "tmpl": {
@@ -11077,6 +11279,12 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "dev": true
+    },
+    "uuid-parse": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/uuid-parse/-/uuid-parse-1.1.0.tgz",
+      "integrity": "sha512-OdmXxA8rDsQ7YpNVbKSJkNzTw2I+S5WsbMDnCtIWSQaosNAcWtFuI/YK1TjzUI6nbkgiqEyh8gWngfcv8Asd9A==",
       "dev": true
     },
     "v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -4,9 +4,11 @@
   "repository": "git+https://github.com/GoogleChromeLabs/wpp-research.git",
   "devDependencies": {
     "@wordpress/scripts": "^24.0.0",
+    "autocannon": "^7.10.0",
     "chalk": "^4.1.2",
     "commander": "^9.4.1",
     "csv-stringify": "^6.2.0",
+    "lodash-es": "4.17.21",
     "node-fetch": "^3.3.0",
     "table": "^6.8.0"
   },


### PR DESCRIPTION
Originally from https://github.com/WordPress/performance/blob/3cc0edcf5d495adbcd2dfede1c4ffdda73b97c6d/bin/plugin/commands/benchmark.js, implemented by @eugene-manuilov.

This is better suited for within this repository than the Performance Lab one, as it's not strictly related to the plugin.

The name is changed from `benchmark` to `benchmark-url`, to be a bit more specific what this command is for.

This PR also updates the code to fit into this repository (e.g. ES imports/exports, using the `table` helper function which simplifies the code here a bit).

The output should 100% match what the original command would produce.