### PR TITLE
Enhance `wpt-metrics` command to support Server-Timing as well as aggregate metrics

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -27,7 +27,7 @@ By default, only the median values are returned. You can optionally request all 
 #### Required arguments
 
 * `--test` (`-t`): You need to pass a WebPageTest result ID (e.g. "221011_AiDcV7_GGM") or URL (e.g. "https://www.webpagetest.org/result/221011_AiDcV7_GGM/"). You can optionally pass multiple test result IDs to merge their metrics. This is usually not relevant but can be helpful to combine multiple results with similar test configuration, to effectively have more test runs than the limit of 9 that WebPageTest imposes.
-* `--metrics` (`-m`): You need to pass one or more WebPageTest metrics. Any metrics available on the "Graph Page Data" view (e.g. "https://www.webpagetest.org/graph_page_data.php?tests=221011_AiDcV7_GGM&median_value=1") are available. For a full list, please see the source code of the `createGetSingleMetricValue_()` function in the `lib/wpt/result.mjs` file. Additionally, you can access any Server-Timing metric by its identifier prefixed with "Server-Timing:". You can even aggregate multiple metrics in one via addition and/or subtraction.
+* `--metrics` (`-m`): You need to pass one or more WebPageTest metrics. Any metrics available on the "Graph Page Data" view (e.g. "https://www.webpagetest.org/graph_page_data.php?tests=221011_AiDcV7_GGM&median_value=1") are available. For a full list, please see the source code of the `createGetSingleMetricValue_()` function in the `lib/wpt/result.mjs` file. Additionally, you can access any Server-Timing metric by its identifier prefixed with "Server-Timing:". You can even aggregate multiple metrics in one via addition (` + `) and/or subtraction (` - `). Make sure to include a space before and after the arithmetic operator.
 
 #### Examples
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -27,7 +27,7 @@ By default, only the median values are returned. You can optionally request all 
 #### Required arguments
 
 * `--test` (`-t`): You need to pass a WebPageTest result ID (e.g. "221011_AiDcV7_GGM") or URL (e.g. "https://www.webpagetest.org/result/221011_AiDcV7_GGM/"). You can optionally pass multiple test result IDs to merge their metrics. This is usually not relevant but can be helpful to combine multiple results with similar test configuration, to effectively have more test runs than the limit of 9 that WebPageTest imposes.
-* `--metrics` (`-m`): You need to pass one or more WebPageTest metrics. Any metrics available on the "Graph Page Data" view (e.g. "https://www.webpagetest.org/graph_page_data.php?tests=221011_AiDcV7_GGM&median_value=1") are available. For a full list, please see the source code of the `createGetMetricValue_()` function in the `lib/wpt/result.mjs` file.
+* `--metrics` (`-m`): You need to pass one or more WebPageTest metrics. Any metrics available on the "Graph Page Data" view (e.g. "https://www.webpagetest.org/graph_page_data.php?tests=221011_AiDcV7_GGM&median_value=1") are available. For a full list, please see the source code of the `createGetSingleMetricValue_()` function in the `lib/wpt/result.mjs` file. Additionally, you can access any Server-Timing metric by its identifier prefixed with "Server-Timing:". You can even aggregate multiple metrics in one via addition and/or subtraction.
 
 #### Examples
 
@@ -49,6 +49,21 @@ wpt-metrics --test 221011_AiDcV7_GGM --metrics TTFB --include-runs
 Get Cumulative Layout Shift median _and_ all individual run values, with rows and columns inverted:
 ```
 wpt-metrics --test 221011_AiDcV7_GGM --metrics CLS --include-runs --rows-as-columns
+```
+
+Get median value for the difference between Largest Contentful Paint and Time to First Byte:
+```
+wpt-metrics --test 221011_AiDcV7_GGM --metrics "LCP - TTFB"
+```
+
+Get median value for a Server-Timing metric called "wp-before-template":
+```
+wpt-metrics --test 221011_AiDcV7_GGM --metrics Server-Timing:wp-before-template
+```
+
+Get median value for the sum of two Server-Timing metrics "wp-before-template" and "wp-template":
+```
+wpt-metrics --test 221011_AiDcV7_GGM --metrics "Server-Timing:wp-before-template + Server-Timing:wp-template"
 ```
 
 ### `wpt-server-timing`

--- a/cli/lib/util/math.mjs
+++ b/cli/lib/util/math.mjs
@@ -17,12 +17,14 @@
  */
 
 export function calcMedian( values ) {
-	const len = values.length;
+	const notNullValues = values.filter( ( value ) => value !== null );
+
+	const len = notNullValues.length;
 	if ( len === 0 ) {
 		return 0;
 	}
 
-	const list = [ ...values ];
+	const list = [ ...notNullValues ];
 	list.sort( ( a, b ) => b - a );
 
 	return len % 2 === 0

--- a/cli/lib/wpt/result.mjs
+++ b/cli/lib/wpt/result.mjs
@@ -205,7 +205,16 @@ export function getResultMetrics( result, ...metrics ) {
 		const getMetricValue = createGetMetricValue_( metric );
 
 		runs.forEach( ( run ) => {
-			values.push( getMetricValue( run ) );
+			let value;
+			try {
+				value = getMetricValue( run );
+			} catch ( e ) {
+				value = null;
+			}
+			if ( value === undefined ) {
+				value = null;
+			}
+			values.push( value );
 		} );
 
 		return {

--- a/cli/lib/wpt/result.mjs
+++ b/cli/lib/wpt/result.mjs
@@ -249,6 +249,10 @@ export function getResultMetrics( result, ...metrics ) {
 			try {
 				value = getMetricValue( run );
 			} catch ( e ) {
+				// Only re-throw error if it's about an invalid Server-Timing metric.
+				if ( e.message.includes( 'Server-Timing metric' ) ) {
+					throw e;
+				}
 				value = null;
 			}
 			if ( value === undefined ) {

--- a/cli/lib/wpt/result.mjs
+++ b/cli/lib/wpt/result.mjs
@@ -175,6 +175,11 @@ function createGetMetricValue_( metric ) {
 		return createGetSingleMetricValue_( metric );
 	} );
 
+	// Simple scenario of just one metric.
+	if ( toAddCallbacks.length === 1 && toSubtractCallbacks.length === 0 ) {
+		return toAddCallbacks.shift();
+	}
+
 	return ( run ) => {
 		const toAddValues = toAddCallbacks.map( ( getValue ) => getValue( run ) );
 		const toSubtractValues = toSubtractCallbacks.map( ( getValue ) => getValue( run ) );


### PR DESCRIPTION
This PR enhances the `wpt-metrics` command with the following:
* Support for accessing specific Server-Timing metrics via the identifier prefixed with "Server-Timing:" (e.g. `Server-Timing:wp-before-template`)
* Support for aggregate metrics through simple addition and/or subtraction (e.g. `"LCP - TTFB"`)
* More graceful handling of `undefined` values or errors in lookup (will be treated as `null`)

See the expanded documentation in this PR for comprehensive examples on how to use the above.