### PR TITLE
Add indentation rule for sql file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -30,6 +30,11 @@ insert_final_newline = false
 indent_style = space
 indent_size = 2
 
+[*.sql]
+insert_final_newline = true
+indent_style = space
+indent_size = 2
+
 [*.yml]
 insert_final_newline = false
 indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -31,7 +31,6 @@ indent_style = space
 indent_size = 2
 
 [*.sql]
-insert_final_newline = true
 indent_style = space
 indent_size = 2
 


### PR DESCRIPTION
As discussed at https://github.com/GoogleChromeLabs/wpp-research/pull/19#issuecomment-1371264171, we should add an indentation rule for the`.sql` file.