### PR TITLE
Add query: Critical CSS opportunity query

### DIFF
--- a/sql/2023/01/critical-css-opportunity.sql
+++ b/sql/2023/01/critical-css-opportunity.sql
@@ -19,7 +19,7 @@ SELECT
   client,
   total_wp_sites,
   sites_with_critical_css,
-  (total_wp_sites-sites_with_critical_css) AS sites_without_critical_css,
+  (total_wp_sites - sites_with_critical_css) AS sites_without_critical_css,
   (total_wp_sites - sites_with_critical_css) / total_wp_sites AS opportunity
 FROM (
   SELECT

--- a/sql/2023/01/critical-css-opportunity.sql
+++ b/sql/2023/01/critical-css-opportunity.sql
@@ -1,6 +1,6 @@
 # HTTP Archive query to get % of WordPress sites not having Critical CSS implementation.
 #
-# WPP Research, Copyright 2022 Google LLC
+# WPP Research, Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sql/2023/01/critical-css-opportunity.sql
+++ b/sql/2023/01/critical-css-opportunity.sql
@@ -1,0 +1,62 @@
+# HTTP Archive query to get % of WordPress sites not having Critical CSS implementation.
+#
+# WPP Research, Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/16
+CREATE TEMP FUNCTION
+  getRenderBlockingCSSCount(lighthouse STRING)
+  RETURNS INT64
+  LANGUAGE js AS '''
+try {
+const report = JSON.parse(lighthouse);
+const networkItems = report.audits["network-requests"].details.items
+const renderBlockingCss = networkItems.filter(item => item.resourceType == "Stylesheet" && item.priority == "VeryHigh");
+return renderBlockingCss.length
+} catch (e) {
+return -1;
+}
+''';
+SELECT
+  client,
+  total_wp_sites,
+  sites_with_critical_css,
+  (total_wp_sites-sites_with_critical_css) AS sites_without_critical_css,
+  CONCAT(ROUND((total_wp_sites-sites_with_critical_css)*100/total_wp_sites, 3),' %') AS opportunity
+FROM (
+  SELECT
+    ap.client,
+    COUNT(ap.page) AS total_wp_sites,
+    COUNTIF( getRenderBlockingCSSCount(lighthouse) = 0
+      AND IFNULL( REGEXP_CONTAINS( response_body, '<head.+<style(.+)/style>.+/head>' ), FALSE ) ) AS sites_with_critical_css
+  FROM
+    `httparchive.all.pages` ap,
+    UNNEST(technologies) AS technologies,
+    UNNEST(technologies.categories) AS category
+  JOIN
+    `httparchive.all.requests` ar
+  ON
+    ap.page = ar.page
+    AND ap.date = ar.date
+    AND ap.client = ar.client
+  WHERE
+    ap.is_root_page = TRUE
+    AND ar.is_root_page = TRUE
+    AND category = "CMS"
+    AND technologies.technology = "WordPress"
+    AND REGEXP_CONTAINS(JSON_EXTRACT(lighthouse,'$.audits.network-requests.details.items' ), '"priority"')
+    AND ap.date = "2022-11-01"
+  GROUP BY
+    client,
+    response_body )

--- a/sql/2023/01/critical-css-opportunity.sql
+++ b/sql/2023/01/critical-css-opportunity.sql
@@ -20,7 +20,7 @@ SELECT
   total_wp_sites,
   sites_with_critical_css,
   (total_wp_sites-sites_with_critical_css) AS sites_without_critical_css,
-  CONCAT(ROUND((total_wp_sites-sites_with_critical_css)*100/total_wp_sites, 3),' %') AS opportunity
+  (total_wp_sites - sites_with_critical_css) / total_wp_sites AS opportunity
 FROM (
   SELECT
     pages._TABLE_SUFFIX AS client,

--- a/sql/2023/01/critical-css-opportunity.sql
+++ b/sql/2023/01/critical-css-opportunity.sql
@@ -15,19 +15,6 @@
 # limitations under the License.
 
 # See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/16
-CREATE TEMP FUNCTION
-  getRenderBlockingCSSCount(lighthouse STRING)
-  RETURNS INT64
-  LANGUAGE js AS '''
-try {
-const report = JSON.parse(lighthouse);
-const networkItems = report.audits["network-requests"].details.items
-const renderBlockingCss = networkItems.filter(item => item.resourceType == "Stylesheet" && item.priority == "VeryHigh");
-return renderBlockingCss.length
-} catch (e) {
-return -1;
-}
-''';
 SELECT
   client,
   total_wp_sites,
@@ -36,27 +23,13 @@ SELECT
   CONCAT(ROUND((total_wp_sites-sites_with_critical_css)*100/total_wp_sites, 3),' %') AS opportunity
 FROM (
   SELECT
-    ap.client,
-    COUNT(ap.page) AS total_wp_sites,
-    COUNTIF( getRenderBlockingCSSCount(lighthouse) = 0
-      AND IFNULL( REGEXP_CONTAINS( response_body, '<head.+<style(.+)/style>.+/head>' ), FALSE ) ) AS sites_with_critical_css
+    pages._TABLE_SUFFIX AS client,
+    COUNT(pages.url) AS total_wp_sites,
+    COUNTIF( CAST(JSON_EXTRACT_SCALAR(payload, '$._renderBlockingCSS') AS INT64) = 0
+      AND CAST(JSON_EXTRACT_SCALAR(payload, '$._inline_style_bytes') AS INT64) > 0 ) AS sites_with_critical_css
   FROM
-    `httparchive.all.pages` ap,
-    UNNEST(technologies) AS technologies,
-    UNNEST(technologies.categories) AS category
-  JOIN
-    `httparchive.all.requests` ar
-  ON
-    ap.page = ar.page
-    AND ap.date = ar.date
-    AND ap.client = ar.client
+    `httparchive.pages.2022_10_01_*` AS pages
   WHERE
-    ap.is_root_page = TRUE
-    AND ar.is_root_page = TRUE
-    AND category = "CMS"
-    AND technologies.technology = "WordPress"
-    AND REGEXP_CONTAINS(JSON_EXTRACT(lighthouse,'$.audits.network-requests.details.items' ), '"priority"')
-    AND ap.date = "2022-11-01"
+    JSON_EXTRACT(pages.payload, '$._detected_apps.WordPress') IS NOT NULL
   GROUP BY
-    client,
-    response_body )
+    pages._TABLE_SUFFIX )

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,10 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/01
+
+* [% of WordPress sites that do not implement Critical CSS](./2023/01/critical-css-opportunity.sql)
+
 ### 2022/12
 
 * [% of WordPress sites that use core theme with jQuery in a given month](./2022/12/usage-of-core-themes-with-jquery.sql)


### PR DESCRIPTION
Fixes #16

## Assumption
* If no CSS is render-blocking, then there is a good chance that it is using critical CSS implementation. 
* if there is no render-blocking CSS, some part of inline_style is in the head.

## RESULTS
client | total_wp_sites | sites_with_critical_css | sites_without_critical_css | opportunity
-- | -- | -- | -- | --
mobile | 5465547 | 241231 | 5224316 | 95.586 %
desktop | 3502837 | 163592 | 3339245 | 95.33 %

Based on October 2022 dataset
