### PR TITLE
Introduce alternative, slightly more efficient version of fetchpriority opportunity query

### DIFF
--- a/sql/2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql
+++ b/sql/2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql
@@ -45,10 +45,10 @@ WITH
 SELECT
   client,
   COUNTIF(fetchpriority = "high"
-    AND nodeName = "IMG" ) AS `with_fetchpriority_on_lcp`,
+    AND nodeName = "IMG" ) AS with_fetchpriority_on_lcp,
   COUNTIF(nodeName = "IMG") - COUNTIF(fetchpriority = "high"
-    AND nodeName = "IMG" ) AS `without_fetchpriority_on_lcp`,
-  COUNTIF(nodeName = "IMG") AS `total_with_lcp`,
+    AND nodeName = "IMG" ) AS without_fetchpriority_on_lcp,
+  COUNTIF(nodeName = "IMG") AS total_with_lcp,
   COUNT(0) AS total_wp_sites,
   (COUNTIF(nodeName = "IMG") - COUNTIF(fetchpriority = "high"
     AND nodeName = "IMG" )) / COUNTIF(nodeName = "IMG") AS pct_opportunity,

--- a/sql/2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql
+++ b/sql/2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql
@@ -1,0 +1,64 @@
+# HTTP Archive query to get % of WordPress sites not having fetchpriority='high' on LCP image.
+#
+# WPP Research, Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/27
+CREATE TEMP FUNCTION
+  getFetchPriorityAttr(attributes STRING)
+  RETURNS STRING
+  LANGUAGE js AS '''
+try {
+  const data = JSON.parse(attributes);
+  const fetchpriorityAttr = data.find(attr => attr["name"] === "fetchpriority")
+  return fetchpriorityAttr.value;
+} catch (e) {
+  return "";
+}
+''';
+
+WITH
+  lcp_stats AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.nodeName') AS nodeName,
+    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.url') AS elementUrl,
+    JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes') AS attributes,
+    JSON_EXTRACT(payload, '$._detected_apps.WordPress') AS wpVersion,
+    getFetchPriorityAttr(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes')) AS fetchpriority,
+  FROM
+    `httparchive.pages.2022_10_01_*`
+)
+
+SELECT
+  client,
+  COUNTIF(fetchpriority = "high"
+    AND nodeName = "IMG" ) AS `with_fetchpriority_on_lcp`,
+  COUNTIF(nodeName = "IMG") - COUNTIF(fetchpriority = "high"
+    AND nodeName = "IMG" ) AS `without_fetchpriority_on_lcp`,
+  COUNTIF(nodeName = "IMG") AS `total_with_lcp`,
+  COUNT(0) AS total_wp_sites,
+  (COUNTIF(nodeName = "IMG") - COUNTIF(fetchpriority = "high"
+    AND nodeName = "IMG" )) / COUNTIF(nodeName = "IMG") AS pct_opportunity,
+  (COUNTIF(nodeName = "IMG") - COUNTIF(fetchpriority = "high"
+    AND nodeName = "IMG" )) / COUNT(0) AS pct_overall_opportunity
+FROM
+  lcp_stats
+WHERE
+  wpVersion IS NOT NULL
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql
+++ b/sql/2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql
@@ -1,6 +1,6 @@
 # HTTP Archive query to get % of WordPress sites not having fetchpriority='high' on LCP image.
 #
-# WPP Research, Copyright 2022 Google LLC
+# WPP Research, Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,10 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/01
+
+* [% of WordPress sites not having fetchpriority='high' on LCP image (slightly more efficient)](./2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql)
+
 ### 2022/12
 
 * [% of WordPress sites that use core theme with jQuery in a given month](./2022/12/usage-of-core-themes-with-jquery.sql)


### PR DESCRIPTION
This query is a slightly more efficient version of the query introduced in #15. The results are pretty much the same, except for some extremely small differences that are natural given that one uses the overall table while this one uses the monthly tables.

One thing to note is that for now this query is set for `October 1, 2022` results instead of `November 1, 2022`, since for some reason HTTP Archive is currently still missing the mobile results for November. That shouldn't matter too much though, we can always rerun the query later for a newer dataset.

This version of the query is heavily inspired by https://discuss.httparchive.org/t/lazy-loaded-lcp-images-by-wordpress-version/2455/2.

Comparing the two queries in terms of efficiency (when running both queries against the October dataset), both take roughly the same time to complete. However this query consumes only 4.18 TB while the other one consumes 7.91 TB.

This PR does not overwrite the original query as it is worth keeping both versions for reference.

## Query results

Row | client | with_fetchpriority_on_lcp | without_fetchpriority_on_lcp | total_with_lcp | total_wp_sites | pct_opportunity | pct_overall_opportunity
-- | -- | -- | -- | -- | -- | -- | --
1 | desktop | 284 | 1503490 | 1503774 | 3502837 | 0.99981114183381281 | 0.42922065742710835
2 | mobile | 337 | 2091778 | 2092115 | 5465547 | 0.99983891898867894 | 0.382720704

For comparison, the results for the query from #15 for the same month are:

Row | client | with_fetchpriority_on_lcp | without_fetchpriority_on_lcp | total_with_lcp | total_wp_sites | opportunity | overall_opportunity
-- | -- | -- | -- | -- | -- | -- | --
1 | desktop | 284 | 1504820 | 1505104 | 3505796 | 99.981 % | 42.924 %
2 | mobile | 337 | 2092862 | 2093199 | 5468298 | 99.984 % | 38.273 %



Based on October 2022 dataset