### PR TITLE
Implement query to assess lazy-loaded LCP image fix opportunity

### DIFF
--- a/sql/2023/01/lazyloaded-lcp-opportunity.sql
+++ b/sql/2023/01/lazyloaded-lcp-opportunity.sql
@@ -1,0 +1,66 @@
+# HTTP Archive query to get % of WordPress sites that lazy-load their LCP image.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/28
+CREATE TEMP FUNCTION
+  getLoadingAttr(attributes STRING)
+  RETURNS STRING
+  LANGUAGE js AS '''
+  try {
+    const data = JSON.parse(attributes);
+    const loadingAttr = data.find(attr => attr["name"] === "loading")
+    return loadingAttr.value
+  } catch (e) {
+    return "";
+  }
+''';
+
+WITH
+  lcp_stats AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.nodeName') AS nodeName,
+    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.url') AS elementUrl,
+    JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes') AS attributes,
+    JSON_EXTRACT(payload, '$._detected_apps.WordPress') AS wpVersion,
+    getLoadingAttr(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes')) AS loading,
+  FROM
+    `httparchive.pages.2022_10_01_*`
+)
+
+SELECT
+  client,
+  COUNTIF(loading = "lazy"
+    AND nodeName = "IMG") AS with_lazyloaded_lcp_image,
+  COUNTIF(nodeName = "IMG") AS with_lcp_image,
+  COUNT(0) AS total_wp_sites,
+  COUNTIF(loading = "lazy"
+    AND nodeName = "IMG") / COUNTIF(nodeName = "IMG") AS pct_lcp_image_opportunity,
+  COUNTIF(loading = "lazy"
+    AND nodeName = "IMG") / COUNT(0) AS pct_total_opportunity,
+  # For reference, include number of sites greater than or equal to WP 5.5. Sites without a known version can be considered
+  # part of this since at this point they are most likely on a more recent version.
+  COUNTIF(wpVersion = '""'
+    OR CAST(REGEXP_EXTRACT(wpVersion, r'^"(\d+\.\d+)') AS FLOAT64) >= 5.5) AS wp_gte_55
+FROM
+  lcp_stats
+WHERE
+  wpVersion IS NOT NULL
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,10 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/01
+
+* [% of WordPress sites that lazy-load their LCP image](./2023/01/lazyloaded-lcp-opportunity.sql)
+
 ### 2022/12
 
 * [% of WordPress sites that use core theme with jQuery in a given month](./2022/12/usage-of-core-themes-with-jquery.sql)


### PR DESCRIPTION
Fixes #8 

Inspired by https://discuss.httparchive.org/t/lazy-loaded-lcp-images-by-wordpress-version/2455/2, this query allows to assess the opportunity of fixing the remaining problems where WordPress sites lazy-load their LCP image.

The query includes the opportunity relative to the number of WordPress sites that actually have an LCP image, but also relative to the total number of WordPress sites. For reference, the query also shows the number of sites on a WordPress version greater than or equal to 5.5, since that is when lazy-loading was introduced in WordPress core.

## Query results

Row | client | with_lazyloaded_lcp_image | with_lcp_image | total_wp_sites | pct_lcp_image_opportunity | pct_total_opportunity | wp_gte_55
-- | -- | -- | -- | -- | -- | -- | --
1 | desktop | 321428 | 1503774 | 3502837 | 0.21374754451134279 | 0.091762191617822925 | 3164718
2 | mobile | 434920 | 2092115 | 5465547 | 0.20788532179158412 | 0.079574834870142 | 4857803

Based on October 2022 dataset