### PR TITLE
Implement 2 queries to assess usage of deferred scripts in WordPress sites

### DIFF
--- a/sql/2023/01/external-deferred-scripts-distribution.sql
+++ b/sql/2023/01/external-deferred-scripts-distribution.sql
@@ -1,0 +1,34 @@
+# HTTP Archive query to get distribution of number of external scripts and % of deferred scripts.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/29
+SELECT
+  _TABLE_SUFFIX AS client,
+  percentile,
+  APPROX_QUANTILES(CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.src') AS INT64), 1000)[OFFSET(percentile * 10)] AS external_scripts,
+  APPROX_QUANTILES(CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.defer') AS INT64) / CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.src') AS INT64), 1000)[OFFSET(percentile * 10)] AS pct_deferred
+FROM
+  `httparchive.pages.2022_10_01_*`,
+  UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
+WHERE
+  JSON_EXTRACT(payload, '$._detected_apps.WordPress') IS NOT NULL
+  AND CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.src') AS INT64) > 0
+GROUP BY
+  client,
+  percentile
+ORDER BY
+  client,
+  percentile

--- a/sql/2023/01/sites-with-deferred-scripts.sql
+++ b/sql/2023/01/sites-with-deferred-scripts.sql
@@ -1,0 +1,29 @@
+# HTTP Archive query to get % of WordPress sites that have any deferred scripts.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/29
+SELECT
+  _TABLE_SUFFIX AS client,
+  COUNTIF(CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.defer') AS INT64) > 0) AS with_deferred_scripts,
+  COUNTIF(CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.src') AS INT64) > 0) AS with_any_external_scripts,
+  COUNT(0) AS total_wp_sites,
+  COUNTIF(CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.defer') AS INT64) > 0) / COUNT(0) AS defer_pct,
+FROM
+  `httparchive.pages.2022_10_01_*`
+WHERE
+  JSON_EXTRACT(payload, '$._detected_apps.WordPress') IS NOT NULL
+GROUP BY
+  client

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,11 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/01
+
+* [% of WordPress sites that have any deferred scripts](./2023/01/sites-with-deferred-scripts.sql)
+* [Distribution of number of external scripts and % of deferred scripts](./2023/01/external-deferred-scripts-distribution.sql)
+
 ### 2022/12
 
 * [% of WordPress sites that use core theme with jQuery in a given month](./2022/12/usage-of-core-themes-with-jquery.sql)


### PR DESCRIPTION
Fixes #7 

This PR introduces 2 HTTP Archive queries:
* one to see how many WP sites use any deferred scripts, as well as any external scripts at all
* another one to get a distribution of how many external scripts are used and what % of them are deferred

These queries are heavily inspired by some of the queries from https://almanac.httparchive.org/en/2022/javascript.

## Query results

### % of WordPress sites that have any deferred scripts

Row | client | with_deferred_scripts | with_any_external_scripts | total_wp_sites | defer_pct
-- | -- | -- | -- | -- | --
1 | desktop | 2836721 | 3453947 | 3502837 | 0.80983528494189139
2 | mobile | 4456183 | 5390184 | 5465547 | 0.815322418

### Distribution of number of external scripts and % of deferred scripts

Row | client | percentile | external_scripts | pct_deferred
-- | -- | -- | -- | --
1 | desktop | 10 | 8 | 0.0
2 | desktop | 25 | 14 | 0.023255813953488372
3 | desktop | 50 | 23 | 0.052631578947368418
4 | desktop | 75 | 36 | 0.1111111111111111
5 | desktop | 90 | 52 | 0.2857142857142857
6 | desktop | 100 | 5564 | 36.0
7 | mobile | 10 | 8 | 0.0
8 | mobile | 25 | 13 | 0.024390243902439025
9 | mobile | 50 | 22 | 0.052631578947368418
10 | mobile | 75 | 34 | 0.11764705882352941
11 | mobile | 90 | 50 | 0.3
12 | mobile | 100 | 2214 | 41.0

Based on October 2022 dataset