### PR TITLE
Implement HTTP Archive query to assess usage of block themes.

### DIFF
--- a/sql/2023/01/block-theme-usage.sql
+++ b/sql/2023/01/block-theme-usage.sql
@@ -1,0 +1,53 @@
+# HTTP Archive query to get % WordPress sites using a block theme.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/32
+SELECT
+  _TABLE_SUFFIX AS client,
+  COUNT(DISTINCT url) AS with_block_theme,
+  total_wp_sites,
+  COUNT(DISTINCT url) / total_wp_sites AS pct_total,
+  # For reference, include number of sites greater than or equal to WP 5.9, since only then block theme support was launched.
+  wp_gte_59
+FROM
+  `httparchive.technologies.2022_11_01_*`
+JOIN
+  `httparchive.response_bodies.2022_11_01_*`
+USING
+  (_TABLE_SUFFIX, url)
+JOIN (
+  SELECT
+    _TABLE_SUFFIX,
+    COUNT(DISTINCT IF (info = '' OR CAST(REGEXP_EXTRACT(info, r'^(\d+\.\d+)') AS FLOAT64) >= 5.9, url, NULL)) AS wp_gte_59,
+    COUNT(DISTINCT url) AS total_wp_sites
+  FROM
+    `httparchive.technologies.2022_11_01_*`
+  WHERE
+    app = "WordPress"
+  GROUP BY
+    _TABLE_SUFFIX )
+USING
+  (_TABLE_SUFFIX)
+WHERE
+  app = "WordPress"
+  AND (info = '' OR CAST(REGEXP_EXTRACT(info, r'^(\d+\.\d+)') AS FLOAT64) >= 5.9)
+  AND body LIKE '%<div class="wp-site-blocks">%'
+GROUP BY
+  client,
+  wp_gte_59,
+  total_wp_sites
+ORDER BY
+  client

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,10 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/01
+
+* [% WordPress sites using a block theme](./2023/01/block-theme-usage.sql)
+
 ### 2022/12
 
 * [% of WordPress sites that use core theme with jQuery in a given month](./2022/12/usage-of-core-themes-with-jquery.sql)


### PR DESCRIPTION
Fixes #9

This query identifies sites using a block theme by checking for the `<div class="wp-site-blocks">` tag which is present in all such sites, as controlled by WordPress core.

## Query results

Row | client | with_block_theme | total_wp_sites | pct_total | wp_gte_59
-- | -- | -- | -- | -- | --
1 | desktop | 7190 | 4241264 | 0.0016952493407625651 | 3393158
2 | mobile | 13074 | 5703734 | 0.0022921826298351222 | 4471610

Based on November 2022 dataset