### PR TITLE
Impact of third-party render blocking scripts

### DIFF
--- a/sql/2023/01/lazyloaded-lcp-opportunity.sql
+++ b/sql/2023/01/lazyloaded-lcp-opportunity.sql
@@ -1,0 +1,66 @@
+# HTTP Archive query to get % of WordPress sites that lazy-load their LCP image.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/28
+CREATE TEMP FUNCTION
+  getLoadingAttr(attributes STRING)
+  RETURNS STRING
+  LANGUAGE js AS '''
+  try {
+    const data = JSON.parse(attributes);
+    const loadingAttr = data.find(attr => attr["name"] === "loading")
+    return loadingAttr.value
+  } catch (e) {
+    return "";
+  }
+''';
+
+WITH
+  lcp_stats AS (
+  SELECT
+    _TABLE_SUFFIX AS client,
+    url,
+    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.nodeName') AS nodeName,
+    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.url') AS elementUrl,
+    JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes') AS attributes,
+    JSON_EXTRACT(payload, '$._detected_apps.WordPress') AS wpVersion,
+    getLoadingAttr(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes')) AS loading,
+  FROM
+    `httparchive.pages.2022_10_01_*`
+)
+
+SELECT
+  client,
+  COUNTIF(loading = "lazy"
+    AND nodeName = "IMG") AS with_lazyloaded_lcp_image,
+  COUNTIF(nodeName = "IMG") AS with_lcp_image,
+  COUNT(0) AS total_wp_sites,
+  COUNTIF(loading = "lazy"
+    AND nodeName = "IMG") / COUNTIF(nodeName = "IMG") AS pct_lcp_image_opportunity,
+  COUNTIF(loading = "lazy"
+    AND nodeName = "IMG") / COUNT(0) AS pct_total_opportunity,
+  # For reference, include number of sites greater than or equal to WP 5.5. Sites without a known version can be considered
+  # part of this since at this point they are most likely on a more recent version.
+  COUNTIF(wpVersion = '""'
+    OR CAST(REGEXP_EXTRACT(wpVersion, r'^"(\d+\.\d+)') AS FLOAT64) >= 5.5) AS wp_gte_55
+FROM
+  lcp_stats
+WHERE
+  wpVersion IS NOT NULL
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/2023/01/third-party-render-blocking-script.sql
+++ b/sql/2023/01/third-party-render-blocking-script.sql
@@ -1,0 +1,60 @@
+# HTTP Archive query to measure the impact of third-party render blocking scripts for WordPress sites.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/33
+SELECT
+  percentile,
+  client,
+  host,
+  APPROX_QUANTILES(requests, 1000)[OFFSET(percentile * 10)] AS num_requests
+FROM (
+  SELECT
+    client,
+    page,
+  IF
+    (NET.HOST(requests.url) IN (
+      SELECT
+        domain
+      FROM
+        `httparchive.almanac.third_parties`
+      WHERE
+        date = '2022-06-01'
+        AND category != 'hosting' ), 'third party', 'first party') AS host,
+    COUNT(0) AS requests
+  FROM
+    `httparchive.almanac.requests` AS requests
+  JOIN
+    `httparchive.pages.2022_06_01_*` AS pages
+  ON
+    pages.url = requests.page
+  WHERE
+    date = '2022-06-01'
+    AND type = 'script'
+    AND JSON_EXTRACT(pages.payload, '$._detected_apps.WordPress') IS NOT NULL
+    AND CAST(JSON_EXTRACT( pages.payload, '$._renderBlockingJS') AS INT64) > 0
+  GROUP BY
+    client,
+    page,
+    host),
+  UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
+GROUP BY
+  percentile,
+  client,
+  host
+ORDER BY
+  client,
+  percentile,
+  host

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,10 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/01
+
+* [impact of third-party render blocking scripts](./2023/01/third-party-render-blocking-script.sql)
+
 ### 2022/12
 
 * [% of WordPress sites that use core theme with jQuery in a given month](./2022/12/usage-of-core-themes-with-jquery.sql)


### PR DESCRIPTION
Fixes #30 

## Query results

Row | percentile | client | host | num_requests
-- | -- | -- | -- | --
1 | 10 | desktop | first party | 8
2 | 10 | desktop | third party | 4
3 | 25 | desktop | first party | 16
4 | 25 | desktop | third party | 10
5 | 50 | desktop | first party | 32
6 | 50 | desktop | third party | 22
7 | 75 | desktop | first party | 56
8 | 75 | desktop | third party | 42
9 | 90 | desktop | first party | 86
10 | 90 | desktop | third party | 68
11 | 100 | desktop | first party | 3320
12 | 100 | desktop | third party | 11578
13 | 10 | mobile | first party | 6
14 | 10 | mobile | third party | 3
15 | 25 | mobile | first party | 12
16 | 25 | mobile | third party | 6
17 | 50 | mobile | first party | 24
18 | 50 | mobile | third party | 16
19 | 75 | mobile | first party | 45
20 | 75 | mobile | third party | 34
21 | 90 | mobile | first party | 74
22 | 90 | mobile | third party | 56
23 | 100 | mobile | first party | 2174
24 | 100 | mobile | third party | 2324

Based on June 2022 dataset.

For the query use below references:
- https://almanac.httparchive.org/en/2022/javascript#requests
- https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2022/javascript/requests_by_3p.sql
- https://github.com/HTTPArchive/almanac.httparchive.org/blob/main/sql/2022/javascript/render_blocking_javascript.sql 