### PR TITLE
Implement queries to assess impact of the WordPress alloptions query

### DIFF
--- a/sql/2023/01/alloptions-query-time-distribution.sql
+++ b/sql/2023/01/alloptions-query-time-distribution.sql
@@ -1,0 +1,57 @@
+# HTTP Archive query to get distribution of alloptions query time and its percentage of the total load time.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/36
+CREATE TEMP FUNCTION EXTRACT_SERVER_TIMING_METRIC(metrics ARRAY<STRUCT<name STRING, dur STRING, `desc` STRING>>, metric_name STRING) RETURNS FLOAT64 LANGUAGE js AS r'''
+const entry = metrics.find(metric => metric.name === metric_name);
+if ( ! entry ) {
+  return null;
+}
+return parseFloat(entry.dur);
+''';
+
+WITH relevantServerTimings AS (
+  SELECT
+    client,
+    url,
+    EXTRACT_SERVER_TIMING_METRIC(httparchive.all.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-load-alloptions-query') AS alloptions_query_time,
+    EXTRACT_SERVER_TIMING_METRIC(httparchive.all.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-before-template') AS before_template_time
+  FROM
+    `httparchive.all.requests`,
+    UNNEST(response_headers) AS response_header
+  WHERE
+    date = '2023-01-01'
+    AND type = "html"
+    AND LOWER(response_header.name) = 'server-timing'
+    # Checking for this value here means we can skip joining the results with the technologies data
+    # since realistically only WordPress sites will provide this Server-Timing header metric.
+    AND CONTAINS_SUBSTR(response_header.value, 'wp-load-alloptions-query;')
+)
+
+SELECT
+  client,
+  percentile,
+  APPROX_QUANTILES(alloptions_query_time, 1000)[OFFSET(percentile * 10)] AS alloptions_query_time,
+  APPROX_QUANTILES(alloptions_query_time / before_template_time, 1000)[OFFSET(percentile * 10)] AS pct_query_time
+FROM
+  relevantServerTimings,
+  UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
+GROUP BY
+  client,
+  percentile
+ORDER BY
+  client,
+  percentile

--- a/sql/2023/01/sites-with-slow-alloptions-queries.sql
+++ b/sql/2023/01/sites-with-slow-alloptions-queries.sql
@@ -1,0 +1,57 @@
+# HTTP Archive query to get number of sites with slow alloptions queries (>10% of total load time).
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/36
+CREATE TEMP FUNCTION EXTRACT_SERVER_TIMING_METRIC(metrics ARRAY<STRUCT<name STRING, dur STRING, `desc` STRING>>, metric_name STRING) RETURNS FLOAT64 LANGUAGE js AS r'''
+const entry = metrics.find(metric => metric.name === metric_name);
+if ( ! entry ) {
+  return null;
+}
+return parseFloat(entry.dur);
+''';
+
+WITH relevantServerTimings AS (
+  SELECT
+    client,
+    url,
+    EXTRACT_SERVER_TIMING_METRIC(httparchive.all.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-load-alloptions-query') AS alloptions_query_time,
+    EXTRACT_SERVER_TIMING_METRIC(httparchive.all.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-before-template') AS before_template_time
+  FROM
+    `httparchive.all.requests`,
+    UNNEST(response_headers) AS response_header
+  WHERE
+    date = '2023-01-01'
+    AND type = "html"
+    AND LOWER(response_header.name) = 'server-timing'
+    # Checking for this value here means we can skip joining the results with the technologies data
+    # since realistically only WordPress sites will provide this Server-Timing header metric.
+    AND CONTAINS_SUBSTR(response_header.value, 'wp-load-alloptions-query;')
+)
+
+SELECT
+  client,
+  percentage AS query_time_percentage,
+  COUNTIF(alloptions_query_time / before_template_time > percentage) AS sites_slower_than_percentage,
+  COUNTIF(alloptions_query_time / before_template_time > percentage) / COUNT(0) AS pct_total_sites
+FROM
+  relevantServerTimings,
+  UNNEST([0.1, 0.3, 0.5, 0.7, 0.9]) AS percentage
+GROUP BY
+  client,
+  percentage
+ORDER BY
+  client,
+  percentage

--- a/sql/README.md
+++ b/sql/README.md
@@ -27,6 +27,8 @@ Once you are ready to add a new query to the repository, open a pull request fol
 * [% of WordPress sites not having fetchpriority='high' on LCP image (slightly more efficient)](./2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql)
 * [Core Web Vital "good" rates by WordPress version](./2023/01/cwvs-by-wordpress-version.sql)
 * [WebP adoption by WordPress version](./2023/01/webp-adoption-by-wordpress-version.sql)
+* [Distribution of alloptions query time and its percentage of the total load time](./2023/01/alloptions-query-time-distribution.sql)
+* [Number of sites with slow alloptions queries (>10% of total load time)](./2023/01/sites-with-slow-alloptions-queries.sql)
 
 ### 2022/12
 


### PR DESCRIPTION
Fixes #6

The queries implemented in this PR assess the impact of the WordPress `alloptions` query (sometimes alternatively referred to as "autoloaded options query") on the overall WordPress load time. It does so by relying on the Server-Timing metrics measured by the Performance Lab plugin (see https://github.com/WordPress/performance/pull/553), which was launched in the plugin release 1.8.0 in December 2022.

## Query results

### Distribution of alloptions query time and its percentage of the total load time

The columns for absolute query time and percentage need to be considered independently of each other. The first is simply the distribution of alloptions query time, while the latter is the distribution of how much the alloptions query time _relatively_ impacted the overall load time.

Row | client | percentile | alloptions_query_time | pct_query_time
-- | -- | -- | -- | --
1 | desktop | 10 | 1.75 | 0.0020514819868742286
2 | desktop | 25 | 2.91 | 0.0041886723729739573
3 | desktop | 50 | 5.24 | 0.010456115719273615
4 | desktop | 75 | 11.12 | 0.02450306288286036
5 | desktop | 90 | 27.66 | 0.066246880319121168
6 | desktop | 100 | 21869.79 | 0.98989039142314472
7 | mobile | 10 | 1.77 | 0.001982137623594379
8 | mobile | 25 | 2.88 | 0.0040242076366358874
9 | mobile | 50 | 5.25 | 0.0097961814227020064
10 | mobile | 75 | 11.23 | 0.021840509870977774
11 | mobile | 90 | 26.6 | 0.060187469166255551
12 | mobile | 100 | 25230.92 | 0.98667496

Based on January 2023 dataset

### Number of sites with slow alloptions queries (>10% of total load time)

This is supplemental data, just to provide a bit more context on how many sites would see large benefits from improving the alloptions query time (i.e. sites where the query is, relatively speaking, extremely slow). The table only considers sites with a query time that accounts for more than 10% of the overall load time, and includes for various percentages the number and % of sites that have an alloptions query that accounts for a relative performance impact greater than that percentage.

Row | client | query_time_percentage | sites_slower_than_percentage | pct_total_sites
-- | -- | -- | -- | --
1 | desktop | 0.1 | 390 | 0.067849686847599164
2 | desktop | 0.3 | 193 | 0.033576896311760612
3 | desktop | 0.5 | 156 | 0.027139874739039668
4 | desktop | 0.7 | 126 | 0.021920668058455117
5 | desktop | 0.9 | 56 | 0.0097425191370911629
6 | mobile | 0.1 | 445 | 0.0641025641025641
7 | mobile | 0.3 | 230 | 0.033131662345145488
8 | mobile | 0.5 | 191 | 0.027513684817055604
9 | mobile | 0.7 | 149 | 0.021463555171420338
10 | mobile | 0.9 | 51 | 0.00734658

Based on January 2023 dataset