### PR TITLE
Enhance `benchmark-web-vitals` command with additional metrics

### DIFF
--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -97,17 +97,29 @@ export async function handler( opt ) {
 }
 
 async function benchmarkURL( browser, params ) {
-	/*
-	 * For now this only includes load time metrics.
-	 * In the future, additional Web Vitals like CLS, FID, and INP should be
-	 * added, however they are slightly more complex to retrieve through an
-	 * automated headless browser test.
-	 */
 	const metricsDefinition = {
+		CLS: {
+			listen: 'onCLS',
+			global: 'webVitalsCLS',
+			get: () => window.webVitalsCLS,
+			results: [],
+		},
 		FCP: {
 			listen: 'onFCP',
 			global: 'webVitalsFCP',
 			get: () => window.webVitalsFCP,
+			results: [],
+		},
+		FID: {
+			listen: 'onFID',
+			global: 'webVitalsFID',
+			get: () => window.webVitalsFID,
+			results: [],
+		},
+		INP: {
+			listen: 'onINP',
+			global: 'webVitalsINP',
+			get: () => window.webVitalsINP,
 			results: [],
 		},
 		LCP: {


### PR DESCRIPTION
Follow up to #40: The initial version of the `benchmark-web-vitals` command only comes with load time metrics, since other metrics are a bit more complicated to capture in a headless browser request, e.g. CLS and INP require interactions to happen and capture events throughout the page lifecycle, not just load time related.

**This is an early draft intended for iteration in the future.**