### PR TITLE
Add WP Profiler mu-plugin

### DIFF
--- a/plugins/wp-profiler/.wp-env.json
+++ b/plugins/wp-profiler/.wp-env.json
@@ -1,0 +1,11 @@
+{
+    "mappings": {
+        "wp-content/mu-plugins": "./"
+    },
+    "config": {
+        "WP_DEBUG": false,
+        "WP_DEBUG_LOG": false,
+        "WP_DEBUG_DISPLAY": false,
+        "SCRIPT_DEBUG": false
+    }
+}

--- a/plugins/wp-profiler/README.md
+++ b/plugins/wp-profiler/README.md
@@ -1,0 +1,15 @@
+# WP Profiler
+
+WP Profiler is an mu-plugin implementation of the [PHP Profiler](https://github.com/perftools/php-profiler) library to make it easier to submit XHProf profiling data to XHGui.
+
+## Installation instructions
+
+After installing this mu-plugin in your application of choice, you'll need to run `composer install` to install the PHP Profiler library dependency. Next, you will need to configure the profiler settings in `plugin.php` to connect to your XHGui application.
+
+To use this as a standalone profiler with WordPress, a sample `.wp-env.json` configuration is included.
+
+See: https://github.com/WordPress/gutenberg/pull/48147 for the status of having XHProf supported directly in the `@wordpress/env` (i.e., `wp-env`) package.
+
+## Disclaimer
+
+This is not an officially supported Google product

--- a/plugins/wp-profiler/composer.json
+++ b/plugins/wp-profiler/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "perftools/php-profiler": "^1.1"
+    }
+}

--- a/plugins/wp-profiler/plugin.php
+++ b/plugins/wp-profiler/plugin.php
@@ -1,0 +1,34 @@
+<?php
+require __DIR__ . '/vendor/autoload.php';
+
+use Xhgui\Profiler\Profiler;
+use Xhgui\Profiler\ProfilingFlags;
+
+// Add this block inside some bootstrapper or other "early central point in execution"
+try {
+    /**
+     * The constructor will throw an exception if the environment
+     * isn't fit for profiling (extensions missing, other problems)
+     */
+    $profiler = new Profiler(
+        array(
+            'save.handler.upload' => array(
+                // Use docker's internal networking to connect containers.
+                'url' => 'http://host.docker.internal:8142/run/import',
+            ),
+            'profiler.flags' => array(
+                ProfilingFlags::CPU,
+                ProfilingFlags::MEMORY,
+                // Comment out below to include built in PHP functions in profiling output.
+                ProfilingFlags::NO_BUILTINS,
+            ),
+        )
+    );
+
+    // The profiler itself checks whether it should be enabled
+    // for request (executes lambda function from config)
+    $profiler->start();
+} catch (Exception $e){
+    // throw away or log error about profiling instantiation failure
+    error_log($e->getMessage());
+}


### PR DESCRIPTION
This adds an example mu-plugin that can be used for configuring a WordPress environment set up using the `wp-env` package with XHProf support ([related PR](https://github.com/WordPress/gutenberg/pull/48147)).