### PR TITLE
Add support for new `--show-percentiles` arg to get more granular percentiles instead of just median to all commands

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -24,10 +24,14 @@ This command parses the median values for given metrics out of the WebPageTest r
 
 By default, only the median values are returned. You can optionally request all the individual run values as well.
 
-#### Required arguments
+#### Arguments
 
 * `--test` (`-t`): You need to pass a WebPageTest result ID (e.g. "221011_AiDcV7_GGM") or URL (e.g. "https://www.webpagetest.org/result/221011_AiDcV7_GGM/"). You can optionally pass multiple test result IDs to merge their metrics. This is usually not relevant but can be helpful to combine multiple results with similar test configuration, to effectively have more test runs than the limit of 9 that WebPageTest imposes.
 * `--metrics` (`-m`): You need to pass one or more WebPageTest metrics. Any metrics available on the "Graph Page Data" view (e.g. "https://www.webpagetest.org/graph_page_data.php?tests=221011_AiDcV7_GGM&median_value=1") are available. For a full list, please see the source code of the `createGetSingleMetricValue_()` function in the `lib/wpt/result.mjs` file. Additionally, you can access any Server-Timing metric by its identifier prefixed with "Server-Timing:". You can even aggregate multiple metrics in one via addition (` + `) and/or subtraction (` - `). Make sure to include a space before and after the arithmetic operator.
+* `--format` (`-f`): The output format: Either "table" or "csv".
+* `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
+* `--include-runs` (`-i`): Whether to also show the full results for all runs.
+* `--rows-as-columns` (`-r`): Whether to inverse rows and columns.
 
 #### Examples
 
@@ -39,6 +43,11 @@ wpt-metrics --test 221011_AiDcV7_GGM --metrics TTFB FCP LCP
 Same as above, but results are formatted as CSV:
 ```
 wpt-metrics --test 221011_AiDcV7_GGM --metrics TTFB FCP LCP --format csv
+```
+
+Get percentile values for Time to First Byte, First Contentful Paint, and Largest Contentful Paint:
+```
+wpt-metrics --test 221011_AiDcV7_GGM --metrics TTFB FCP LCP --show-percentiles
 ```
 
 Get Time to First Byte median _and_ all individual run values:
@@ -74,9 +83,13 @@ These are not available by default for any WebPageTest result. They are only ava
 
 By default, only the median values are returned. You can optionally request all the individual run values as well.
 
-#### Required arguments
+#### Arguments
 
 * `--test` (`-t`): You need to pass a WebPageTest result ID (e.g. "221011_AiDcV7_GGM") or URL (e.g. "https://www.webpagetest.org/result/221011_AiDcV7_GGM/"). You can optionally pass multiple test result IDs to merge their metrics. This is usually not relevant but can be helpful to combine multiple results with similar test configuration, to effectively have more test runs than the limit of 9 that WebPageTest imposes.
+* `--format` (`-f`): The output format: Either "table" or "csv".
+* `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
+* `--include-runs` (`-i`): Whether to also show the full results for all runs.
+* `--rows-as-columns` (`-r`): Whether to inverse rows and columns.
 
 #### Examples
 
@@ -88,6 +101,11 @@ wpt-server-timing --test 221011_AiDcV7_GGM
 Same as above, but results are formatted as CSV:
 ```
 wpt-server-timing --test 221011_AiDcV7_GGM --format csv
+```
+
+Get Server-Timing header percentile values:
+```
+wpt-server-timing --test 221011_AiDcV7_GGM --show-percentiles
 ```
 
 Get Server-Timing header medians _and_ all individual run values:
@@ -105,7 +123,8 @@ Sends the selected number of requests with a certain concurrency to provided URL
 * `--concurrency` (`-c`): Number of requests to make at the same time.
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
-* `--output` (`-o`): The output format.
+* `--output` (`-o`): The output format: Either "table" or "csv".
+* `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 
 #### Examples
 
@@ -117,6 +136,11 @@ benchmark-server-timing --url https://example.com/ -n 10 -c 2
 Same as above, but results are formatted as CSV:
 ```
 benchmark-server-timing --url https://example.com/ -n 10 -c 2 --output csv
+```
+
+To include more granular percentiles rather than only the median for each metric:
+```
+benchmark-server-timing --url https://example.com/ -n 10 -c 2 --show-percentiles
 ```
 
 To run benchmark tests for URLs from a file:
@@ -133,7 +157,8 @@ Loads the provided URLs in a headless browser several times to measure median We
 * `--url` (`-u`): A URL to benchmark.
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
-* `--output` (`-o`): The output format.
+* `--output` (`-o`): The output format: Either "table" or "csv".
+* `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 
 #### Examples
 
@@ -145,6 +170,11 @@ benchmark-web-vitals --url https://example.com/ -n 10
 Same as above, but results are formatted as CSV:
 ```
 benchmark-web-vitals --url https://example.com/ -n 10 --output csv
+```
+
+To include more granular percentiles rather than only the median for each metric:
+```
+benchmark-web-vitals --url https://example.com/ -n 10 --show-percentiles
 ```
 
 To run benchmark tests for URLs from a file:

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -34,7 +34,10 @@ import {
 	OUTPUT_FORMAT_TABLE,
 } from '../lib/cli/logger.mjs';
 import { calcPercentile } from '../lib/util/math.mjs';
-import { KEY_PERCENTILES, MEDIAN_PERCENTILES } from '../lib/util/percentiles.mjs';
+import {
+	KEY_PERCENTILES,
+	MEDIAN_PERCENTILES,
+} from '../lib/util/percentiles.mjs';
 
 export const options = [
 	{
@@ -62,7 +65,8 @@ export const options = [
 	},
 	{
 		argname: '-p, --show-percentiles',
-		description: 'Whether to show more granular percentiles instead of only the median',
+		description:
+			'Whether to show more granular percentiles instead of only the median',
 	},
 ];
 
@@ -187,12 +191,11 @@ function outputResults( opt, results ) {
 		}
 	}
 
-	const percentiles = opt.showPercentiles ? KEY_PERCENTILES : MEDIAN_PERCENTILES;
+	const percentiles = opt.showPercentiles
+		? KEY_PERCENTILES
+		: MEDIAN_PERCENTILES;
 
-	const headings = [
-		'URL',
-		'Success Rate',
-	];
+	const headings = [ 'URL', 'Success Rate' ];
 
 	/*
 	 * Alternatively to the if-else below, we could simply iterate through
@@ -227,14 +230,21 @@ function outputResults( opt, results ) {
 		const tableRow = [
 			url,
 			`${ completionRate }%`,
-			...percentiles.map( percentile => round( calcPercentile( percentile, responseTimes ), 2 ) ),
+			...percentiles.map( ( percentile ) =>
+				round( calcPercentile( percentile, responseTimes ), 2 )
+			),
 		];
 		Object.keys( allMetricNames ).forEach( ( metricName ) => {
 			percentiles.forEach( ( percentile ) => {
 				if ( ! metrics[ metricName ] ) {
 					tableRow.push( '' );
 				} else {
-					tableRow.push( round( calcPercentile( percentile, metrics[ metricName ] ), 2 ) );
+					tableRow.push(
+						round(
+							calcPercentile( percentile, metrics[ metricName ] ),
+							2
+						)
+					);
 				}
 			} );
 		} );

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -56,13 +56,13 @@ export const options = [
 		description: 'File with URLs to run benchmark tests for',
 	},
 	{
-		argname: '-p, --show-percentiles',
-		description: 'Whether to show more granular percentiles instead of only the median',
-	},
-	{
 		argname: '-o, --output <output>',
 		description: 'Output format: csv or table',
 		defaults: OUTPUT_FORMAT_TABLE,
+	},
+	{
+		argname: '-p, --show-percentiles',
+		description: 'Whether to show more granular percentiles instead of only the median',
 	},
 ];
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -34,7 +34,10 @@ import {
 	OUTPUT_FORMAT_TABLE,
 } from '../lib/cli/logger.mjs';
 import { calcPercentile } from '../lib/util/math.mjs';
-import { KEY_PERCENTILES, MEDIAN_PERCENTILES } from '../lib/util/percentiles.mjs';
+import {
+	KEY_PERCENTILES,
+	MEDIAN_PERCENTILES,
+} from '../lib/util/percentiles.mjs';
 
 export const options = [
 	{
@@ -57,7 +60,8 @@ export const options = [
 	},
 	{
 		argname: '-p, --show-percentiles',
-		description: 'Whether to show more granular percentiles instead of only the median',
+		description:
+			'Whether to show more granular percentiles instead of only the median',
 	},
 ];
 
@@ -204,12 +208,11 @@ function outputResults( opt, results ) {
 		}
 	}
 
-	const percentiles = opt.showPercentiles ? KEY_PERCENTILES : MEDIAN_PERCENTILES;
+	const percentiles = opt.showPercentiles
+		? KEY_PERCENTILES
+		: MEDIAN_PERCENTILES;
 
-	const headings = [
-		'URL',
-		'Success Rate',
-	];
+	const headings = [ 'URL', 'Success Rate' ];
 
 	/*
 	 * Alternatively to the if-else below, we could simply iterate through
@@ -237,16 +240,18 @@ function outputResults( opt, results ) {
 			1
 		);
 
-		const tableRow = [
-			url,
-			`${ completionRate }%`,
-		];
+		const tableRow = [ url, `${ completionRate }%` ];
 		Object.keys( allMetricNames ).forEach( ( metricName ) => {
 			percentiles.forEach( ( percentile ) => {
 				if ( ! metrics[ metricName ] ) {
 					tableRow.push( '' );
 				} else {
-					tableRow.push( round( calcPercentile( percentile, metrics[ metricName ] ), 2 ) );
+					tableRow.push(
+						round(
+							calcPercentile( percentile, metrics[ metricName ] ),
+							2
+						)
+					);
 				}
 			} );
 		} );

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -33,7 +33,8 @@ import {
 	isValidTableFormat,
 	OUTPUT_FORMAT_TABLE,
 } from '../lib/cli/logger.mjs';
-import { calcMedian } from '../lib/util/math.mjs';
+import { calcPercentile } from '../lib/util/math.mjs';
+import { KEY_PERCENTILES, MEDIAN_PERCENTILES } from '../lib/util/percentiles.mjs';
 
 export const options = [
 	{
@@ -48,6 +49,10 @@ export const options = [
 	{
 		argname: '-f, --file <file>',
 		description: 'File with URLs to run benchmark tests for',
+	},
+	{
+		argname: '-p, --show-percentiles',
+		description: 'Whether to show more granular percentiles instead of only the median',
 	},
 	{
 		argname: '-o, --output <output>',
@@ -189,11 +194,29 @@ function outputResults( opt, results ) {
 		}
 	}
 
+	const percentiles = opt.showPercentiles ? KEY_PERCENTILES : MEDIAN_PERCENTILES;
+
 	const headings = [
 		'URL',
 		'Success Rate',
-		...Object.keys( allMetricNames ),
 	];
+
+	/*
+	 * Alternatively to the if-else below, we could simply iterate through
+	 * the percentiles unconditionally, however in case of median we should
+	 * rather use the easier-to-understand "(median)" label.
+	 */
+	if ( opt.showPercentiles ) {
+		Object.keys( allMetricNames ).forEach( ( metricName ) => {
+			percentiles.forEach( ( percentile ) => {
+				headings.push( `${ metricName } (p${ percentile })` );
+			} );
+		} );
+	} else {
+		Object.keys( allMetricNames ).forEach( ( metricName ) => {
+			headings.push( `${ metricName } (median)` );
+		} );
+	}
 
 	const tableData = [];
 
@@ -204,16 +227,21 @@ function outputResults( opt, results ) {
 			1
 		);
 
-		const vals = { ...allMetricNames };
-		for ( const metric of Object.keys( metrics ) ) {
-			vals[ metric ] = `${ round( calcMedian( metrics[ metric ] ), 2 ) }`;
-		}
-
-		tableData.push( [
+		const tableRow = [
 			url,
 			`${ completionRate }%`,
-			...Object.values( vals ),
-		] );
+		];
+		Object.keys( allMetricNames ).forEach( ( metricName ) => {
+			percentiles.forEach( ( percentile ) => {
+				if ( ! metrics[ metricName ] ) {
+					tableRow.push( '' );
+				} else {
+					tableRow.push( round( calcPercentile( percentile, metrics[ metricName ] ), 2 ) );
+				}
+			} );
+		} );
+
+		tableData.push( tableRow );
 	}
 
 	log( table( headings, tableData, opt.output, true ) );

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -51,13 +51,13 @@ export const options = [
 		description: 'File with URLs to run benchmark tests for',
 	},
 	{
-		argname: '-p, --show-percentiles',
-		description: 'Whether to show more granular percentiles instead of only the median',
-	},
-	{
 		argname: '-o, --output <output>',
 		description: 'Output format: csv or table',
 		defaults: OUTPUT_FORMAT_TABLE,
+	},
+	{
+		argname: '-p, --show-percentiles',
+		description: 'Whether to show more granular percentiles instead of only the median',
 	},
 ];
 

--- a/cli/commands/wpt-metrics.mjs
+++ b/cli/commands/wpt-metrics.mjs
@@ -17,6 +17,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import round from 'lodash-es/round.js';
+
+/**
  * Internal dependencies
  */
 import {
@@ -120,7 +125,7 @@ export async function handler( opt ) {
 			headings.push( `Run ${ i + 1 }` );
 		}
 		parseTableData = ( metric ) => {
-			return [ metric.name, ...percentiles.map( percentile => metric[ `p${ percentile }` ] ), ...metric.runs ];
+			return [ metric.name, ...percentiles.map( percentile => round( metric[ `p${ percentile }` ], 2 ) ), ...metric.runs ];
 		};
 	} else if ( includeRuns ) {
 		headings = [ 'Metric', 'Median' ];
@@ -128,17 +133,17 @@ export async function handler( opt ) {
 			headings.push( `Run ${ i + 1 }` );
 		}
 		parseTableData = ( metric ) => {
-			return [ metric.name, metric.p50, ...metric.runs ];
+			return [ metric.name, round( metric.p50, 2 ), ...metric.runs ];
 		};
 	} else if ( showPercentiles ) {
 		headings = [ 'Metric', ...percentiles.map( percentile => `p${ percentile }` ) ];
 		parseTableData = ( metric ) => {
-			return [ metric.name, ...percentiles.map( percentile => metric[ `p${ percentile }` ] ) ];
+			return [ metric.name, ...percentiles.map( percentile => round( metric[ `p${ percentile }` ], 2 ) ) ];
 		};
 	} else {
 		headings = [ 'Metric', 'Median' ];
 		parseTableData = ( metric ) => {
-			return [ metric.name, metric.p50 ];
+			return [ metric.name, round( metric.p50, 2 ) ];
 		};
 	}
 

--- a/cli/commands/wpt-metrics.mjs
+++ b/cli/commands/wpt-metrics.mjs
@@ -37,7 +37,10 @@ import {
 	getResultMetrics,
 	mergeResultMetrics,
 } from '../lib/wpt/result.mjs';
-import { KEY_PERCENTILES, MEDIAN_PERCENTILES } from '../lib/util/percentiles.mjs';
+import {
+	KEY_PERCENTILES,
+	MEDIAN_PERCENTILES,
+} from '../lib/util/percentiles.mjs';
 
 export const options = [
 	{
@@ -58,7 +61,8 @@ export const options = [
 	},
 	{
 		argname: '-p, --show-percentiles',
-		description: 'Whether to show more granular percentiles instead of only the median',
+		description:
+			'Whether to show more granular percentiles instead of only the median',
 	},
 	{
 		argname: '-i, --include-runs',
@@ -71,7 +75,14 @@ export const options = [
 ];
 
 export async function handler( opt ) {
-	const { test, metrics, format, showPercentiles, includeRuns, rowsAsColumns } = opt;
+	const {
+		test,
+		metrics,
+		format,
+		showPercentiles,
+		includeRuns,
+		rowsAsColumns,
+	} = opt;
 
 	let testIds;
 	try {
@@ -99,7 +110,11 @@ export async function handler( opt ) {
 	await Promise.all(
 		testIds.map( async ( testId ) => {
 			const result = await getResultJson( testId );
-			const resultMetrics = getResultMetrics( percentiles, result, ...metrics );
+			const resultMetrics = getResultMetrics(
+				percentiles,
+				result,
+				...metrics
+			);
 
 			accTestRuns += result.testRuns;
 			resultMetrics.forEach( ( metric ) => {
@@ -120,12 +135,21 @@ export async function handler( opt ) {
 
 	let headings, parseTableData;
 	if ( showPercentiles && includeRuns ) {
-		headings = [ 'Metric', ...percentiles.map( percentile => `p${ percentile }` ) ];
+		headings = [
+			'Metric',
+			...percentiles.map( ( percentile ) => `p${ percentile }` ),
+		];
 		for ( let i = 0; i < accTestRuns; i++ ) {
 			headings.push( `Run ${ i + 1 }` );
 		}
 		parseTableData = ( metric ) => {
-			return [ metric.name, ...percentiles.map( percentile => round( metric[ `p${ percentile }` ], 2 ) ), ...metric.runs ];
+			return [
+				metric.name,
+				...percentiles.map( ( percentile ) =>
+					round( metric[ `p${ percentile }` ], 2 )
+				),
+				...metric.runs,
+			];
 		};
 	} else if ( includeRuns ) {
 		headings = [ 'Metric', 'Median' ];
@@ -136,9 +160,17 @@ export async function handler( opt ) {
 			return [ metric.name, round( metric.p50, 2 ), ...metric.runs ];
 		};
 	} else if ( showPercentiles ) {
-		headings = [ 'Metric', ...percentiles.map( percentile => `p${ percentile }` ) ];
+		headings = [
+			'Metric',
+			...percentiles.map( ( percentile ) => `p${ percentile }` ),
+		];
 		parseTableData = ( metric ) => {
-			return [ metric.name, ...percentiles.map( percentile => round( metric[ `p${ percentile }` ], 2 ) ) ];
+			return [
+				metric.name,
+				...percentiles.map( ( percentile ) =>
+					round( metric[ `p${ percentile }` ], 2 )
+				),
+			];
 		};
 	} else {
 		headings = [ 'Metric', 'Median' ];

--- a/cli/commands/wpt-metrics.mjs
+++ b/cli/commands/wpt-metrics.mjs
@@ -32,6 +32,7 @@ import {
 	getResultMetrics,
 	mergeResultMetrics,
 } from '../lib/wpt/result.mjs';
+import { KEY_PERCENTILES, MEDIAN_PERCENTILES } from '../lib/util/percentiles.mjs';
 
 export const options = [
 	{
@@ -51,6 +52,10 @@ export const options = [
 		defaults: OUTPUT_FORMAT_TABLE,
 	},
 	{
+		argname: '-p, --show-percentiles',
+		description: 'Whether to show more granular percentiles instead of only the median',
+	},
+	{
 		argname: '-i, --include-runs',
 		description: 'Whether to also show the full results for all runs',
 	},
@@ -61,7 +66,7 @@ export const options = [
 ];
 
 export async function handler( opt ) {
-	const { test, metrics, format, includeRuns, rowsAsColumns } = opt;
+	const { test, metrics, format, showPercentiles, includeRuns, rowsAsColumns } = opt;
 
 	let testIds;
 	try {
@@ -80,52 +85,67 @@ export async function handler( opt ) {
 		return;
 	}
 
+	const percentiles = showPercentiles ? KEY_PERCENTILES : MEDIAN_PERCENTILES;
+
 	// Usually only one test ID is passed, but multiple are supported. This can be useful to merge results from
 	// multiple WebPageTest tests, typically with similar configuration, to get more than 9 test runs.
 	let accTestRuns = 0;
-	const accMedianMetrics = {};
+	const accResultMetrics = {};
 	await Promise.all(
 		testIds.map( async ( testId ) => {
 			const result = await getResultJson( testId );
-			const medianMetrics = getResultMetrics( result, ...metrics );
+			const resultMetrics = getResultMetrics( percentiles, result, ...metrics );
 
 			accTestRuns += result.testRuns;
-			medianMetrics.forEach( ( metric ) => {
-				if ( ! accMedianMetrics[ metric.name ] ) {
-					accMedianMetrics[ metric.name ] = [];
+			resultMetrics.forEach( ( metric ) => {
+				if ( ! accResultMetrics[ metric.name ] ) {
+					accResultMetrics[ metric.name ] = [];
 				}
-				accMedianMetrics[ metric.name ].push( metric );
+				accResultMetrics[ metric.name ].push( metric );
 			} );
 		} )
 	);
-	const mergedMedianMetrics = Object.values( accMedianMetrics ).map(
-		( medianMetrics ) => {
-			return medianMetrics.length > 1
-				? mergeResultMetrics( ...medianMetrics )
-				: medianMetrics.shift();
+	const mergedResultMetrics = Object.values( accResultMetrics ).map(
+		( resultMetrics ) => {
+			return resultMetrics.length > 1
+				? mergeResultMetrics( percentiles, ...resultMetrics )
+				: resultMetrics.shift();
 		}
 	);
 
 	let headings, parseTableData;
-	if ( includeRuns ) {
+	if ( showPercentiles && includeRuns ) {
+		headings = [ 'Metric', ...percentiles.map( percentile => `p${ percentile }` ) ];
+		for ( let i = 0; i < accTestRuns; i++ ) {
+			headings.push( `Run ${ i + 1 }` );
+		}
+		parseTableData = ( metric ) => {
+			return [ metric.name, ...percentiles.map( percentile => metric[ `p${ percentile }` ] ), ...metric.runs ];
+		};
+	} else if ( includeRuns ) {
 		headings = [ 'Metric', 'Median' ];
 		for ( let i = 0; i < accTestRuns; i++ ) {
 			headings.push( `Run ${ i + 1 }` );
 		}
 		parseTableData = ( metric ) => {
-			return [ metric.name, metric.median, ...metric.runs ];
+			return [ metric.name, metric.p50, ...metric.runs ];
+		};
+	} else if ( showPercentiles ) {
+		headings = [ 'Metric', ...percentiles.map( percentile => `p${ percentile }` ) ];
+		parseTableData = ( metric ) => {
+			return [ metric.name, ...percentiles.map( percentile => metric[ `p${ percentile }` ] ) ];
 		};
 	} else {
 		headings = [ 'Metric', 'Median' ];
 		parseTableData = ( metric ) => {
-			return [ metric.name, metric.median ];
+			return [ metric.name, metric.p50 ];
 		};
 	}
 
 	log(
 		table(
 			headings,
-			mergedMedianMetrics.map( parseTableData ),
+			mergedResultMetrics.map( parseTableData ),
 			format,
 			rowsAsColumns
 		)

--- a/cli/commands/wpt-server-timing.mjs
+++ b/cli/commands/wpt-server-timing.mjs
@@ -37,7 +37,10 @@ import {
 	getResultServerTiming,
 	mergeResultMetrics,
 } from '../lib/wpt/result.mjs';
-import { KEY_PERCENTILES, MEDIAN_PERCENTILES } from '../lib/util/percentiles.mjs';
+import {
+	KEY_PERCENTILES,
+	MEDIAN_PERCENTILES,
+} from '../lib/util/percentiles.mjs';
 
 export const options = [
 	{
@@ -53,7 +56,8 @@ export const options = [
 	},
 	{
 		argname: '-p, --show-percentiles',
-		description: 'Whether to show more granular percentiles instead of only the median',
+		description:
+			'Whether to show more granular percentiles instead of only the median',
 	},
 	{
 		argname: '-i, --include-runs',
@@ -115,12 +119,21 @@ export async function handler( opt ) {
 
 	let headings, parseTableData;
 	if ( showPercentiles && includeRuns ) {
-		headings = [ 'Metric', ...percentiles.map( percentile => `p${ percentile }` ) ];
+		headings = [
+			'Metric',
+			...percentiles.map( ( percentile ) => `p${ percentile }` ),
+		];
 		for ( let i = 0; i < accTestRuns; i++ ) {
 			headings.push( `Run ${ i + 1 }` );
 		}
 		parseTableData = ( metric ) => {
-			return [ metric.name, ...percentiles.map( percentile => round( metric[ `p${ percentile }` ], 2 ) ), ...metric.runs ];
+			return [
+				metric.name,
+				...percentiles.map( ( percentile ) =>
+					round( metric[ `p${ percentile }` ], 2 )
+				),
+				...metric.runs,
+			];
 		};
 	} else if ( includeRuns ) {
 		headings = [ 'Metric', 'Median' ];
@@ -131,9 +144,17 @@ export async function handler( opt ) {
 			return [ metric.name, round( metric.p50, 2 ), ...metric.runs ];
 		};
 	} else if ( showPercentiles ) {
-		headings = [ 'Metric', ...percentiles.map( percentile => `p${ percentile }` ) ];
+		headings = [
+			'Metric',
+			...percentiles.map( ( percentile ) => `p${ percentile }` ),
+		];
 		parseTableData = ( metric ) => {
-			return [ metric.name, ...percentiles.map( percentile => round( metric[ `p${ percentile }` ], 2 ) ) ];
+			return [
+				metric.name,
+				...percentiles.map( ( percentile ) =>
+					round( metric[ `p${ percentile }` ], 2 )
+				),
+			];
 		};
 	} else {
 		headings = [ 'Metric', 'Median' ];

--- a/cli/commands/wpt-server-timing.mjs
+++ b/cli/commands/wpt-server-timing.mjs
@@ -17,6 +17,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import round from 'lodash-es/round.js';
+
+/**
  * Internal dependencies
  */
 import {
@@ -115,7 +120,7 @@ export async function handler( opt ) {
 			headings.push( `Run ${ i + 1 }` );
 		}
 		parseTableData = ( metric ) => {
-			return [ metric.name, ...percentiles.map( percentile => metric[ `p${ percentile }` ] ), ...metric.runs ];
+			return [ metric.name, ...percentiles.map( percentile => round( metric[ `p${ percentile }` ], 2 ) ), ...metric.runs ];
 		};
 	} else if ( includeRuns ) {
 		headings = [ 'Metric', 'Median' ];
@@ -123,17 +128,17 @@ export async function handler( opt ) {
 			headings.push( `Run ${ i + 1 }` );
 		}
 		parseTableData = ( metric ) => {
-			return [ metric.name, metric.p50, ...metric.runs ];
+			return [ metric.name, round( metric.p50, 2 ), ...metric.runs ];
 		};
 	} else if ( showPercentiles ) {
 		headings = [ 'Metric', ...percentiles.map( percentile => `p${ percentile }` ) ];
 		parseTableData = ( metric ) => {
-			return [ metric.name, ...percentiles.map( percentile => metric[ `p${ percentile }` ] ) ];
+			return [ metric.name, ...percentiles.map( percentile => round( metric[ `p${ percentile }` ], 2 ) ) ];
 		};
 	} else {
 		headings = [ 'Metric', 'Median' ];
 		parseTableData = ( metric ) => {
-			return [ metric.name, metric.p50 ];
+			return [ metric.name, round( metric.p50, 2 ) ];
 		};
 	}
 

--- a/cli/lib/util/math.mjs
+++ b/cli/lib/util/math.mjs
@@ -46,7 +46,7 @@ export function calcPercentile( percentile, values ) {
 	// Otherwise use the weighted value from between the two surrounding indexes.
 	const lowerIndex = Math.floor( index );
 	const upperIndex = lowerIndex + 1;
-	const weight     = index % 1;
+	const weight = index % 1;
 	return list[ lowerIndex ] * ( 1 - weight ) + list[ upperIndex ] * weight;
 }
 

--- a/cli/lib/util/math.mjs
+++ b/cli/lib/util/math.mjs
@@ -24,25 +24,30 @@ export function calcPercentile( percentile, values ) {
 		return 0;
 	}
 
-	// If there is only one value, return that.
-	if ( len === 1 ) {
-		return notNullValues[ 0 ];
-	}
-
 	// Sort values with the lowest first.
 	const list = [ ...notNullValues ];
-	list.sort( ( a, b ) => b - a );
+	list.sort( ( a, b ) => a - b );
+
+	if ( percentile <= 0 ) {
+		return list[ 0 ];
+	}
+	if ( percentile >= 100 ) {
+		return list[ len - 1 ];
+	}
 
 	// Get the index of the highest value in the percentile.
-	const index = ( percentile / 100 ) * len - 1;
+	const index = ( percentile / 100 ) * ( len - 1 );
 
 	// If index is a whole number, return that value directly.
 	if ( index % 1 === 0 ) {
 		return list[ index ];
 	}
 
-	// Otherwise use the average of the two surrounding indexes.
-	return ( list[ Math.floor( index ) ] + list[ Math.ceil( index ) ] ) / 2;
+	// Otherwise use the weighted value from between the two surrounding indexes.
+	const lowerIndex = Math.floor( index );
+	const upperIndex = lowerIndex + 1;
+	const weight     = index % 1;
+	return list[ lowerIndex ] * ( 1 - weight ) + list[ upperIndex ] * weight;
 }
 
 export function calcMedian( values ) {

--- a/cli/lib/util/math.mjs
+++ b/cli/lib/util/math.mjs
@@ -16,7 +16,7 @@
  * limitations under the License.
  */
 
-export function calcMedian( values ) {
+export function calcPercentile( percentile, values ) {
 	const notNullValues = values.filter( ( value ) => value !== null );
 
 	const len = notNullValues.length;
@@ -24,10 +24,27 @@ export function calcMedian( values ) {
 		return 0;
 	}
 
+	// If there is only one value, return that.
+	if ( len === 1 ) {
+		return notNullValues[ 0 ];
+	}
+
+	// Sort values with the lowest first.
 	const list = [ ...notNullValues ];
 	list.sort( ( a, b ) => b - a );
 
-	return len % 2 === 0
-		? ( list[ len / 2 ] + list[ ( len / 2 ) - 1 ] ) / 2
-		: list[ Math.floor( len / 2 ) ];
+	// Get the index of the highest value in the percentile.
+	const index = ( percentile / 100 ) * len - 1;
+
+	// If index is a whole number, return that value directly.
+	if ( index % 1 === 0 ) {
+		return list[ index ];
+	}
+
+	// Otherwise use the average of the two surrounding indexes.
+	return ( list[ Math.floor( index ) ] + list[ Math.ceil( index ) ] ) / 2;
+}
+
+export function calcMedian( values ) {
+	return calcPercentile( 50, values );
 }

--- a/cli/lib/util/percentiles.mjs
+++ b/cli/lib/util/percentiles.mjs
@@ -1,0 +1,20 @@
+/**
+ * Application-wide percentile definitions.
+ *
+ * WPP Research, Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export const KEY_PERCENTILES = [ 10, 25, 50, 75, 90 ];
+export const MEDIAN_PERCENTILES = [ 50 ];

--- a/cli/lib/wpt/result.mjs
+++ b/cli/lib/wpt/result.mjs
@@ -257,7 +257,10 @@ export function mergeResultMetrics( percentiles, ...resultMetrics ) {
 	);
 
 	percentiles.forEach( ( percentile ) => {
-		merged[ `p${ percentile }` ] = calcPercentile( percentile, merged.runs );
+		merged[ `p${ percentile }` ] = calcPercentile(
+			percentile,
+			merged.runs
+		);
 	} );
 
 	return merged;
@@ -354,7 +357,10 @@ export function getResultServerTiming( percentiles, result ) {
 
 		const data = { ...metric };
 		percentiles.forEach( ( percentile ) => {
-			data[ `p${ percentile }` ] = calcPercentile( percentile, metric.runs );
+			data[ `p${ percentile }` ] = calcPercentile(
+				percentile,
+				metric.runs
+			);
 		} );
 		return data;
 	} );

--- a/cli/lib/wpt/result.mjs
+++ b/cli/lib/wpt/result.mjs
@@ -20,7 +20,7 @@
  * Internal dependencies
  */
 import { fetchJson } from '../util/fetch.mjs';
-import { calcMedian } from '../util/math.mjs';
+import { calcPercentile } from '../util/math.mjs';
 
 let getServerTimingHeader;
 
@@ -212,7 +212,7 @@ function createGetResponseHeader_( headerName ) {
 	};
 }
 
-export function mergeResultMetrics( ...resultMetrics ) {
+export function mergeResultMetrics( percentiles, ...resultMetrics ) {
 	const merged = resultMetrics.reduce(
 		( acc, metric ) => {
 			if ( metric.name !== acc.name ) {
@@ -224,16 +224,18 @@ export function mergeResultMetrics( ...resultMetrics ) {
 		},
 		{
 			name: resultMetrics[ 0 ].name,
-			median: 0,
 			runs: [],
 		}
 	);
 
-	merged.median = calcMedian( merged.runs );
+	percentiles.forEach( ( percentile ) => {
+		merged[ `p${ percentile }` ] = calcPercentile( percentile, merged.runs );
+	} );
+
 	return merged;
 }
 
-export function getResultMetrics( result, ...metrics ) {
+export function getResultMetrics( percentiles, result, ...metrics ) {
 	if ( ! metrics || ! metrics.length ) {
 		return [];
 	}
@@ -261,15 +263,18 @@ export function getResultMetrics( result, ...metrics ) {
 			values.push( value );
 		} );
 
-		return {
+		const data = {
 			name: metric,
-			median: calcMedian( values ),
 			runs: values,
 		};
+		percentiles.forEach( ( percentile ) => {
+			data[ `p${ percentile }` ] = calcPercentile( percentile, values );
+		} );
+		return data;
 	} );
 }
 
-export function getResultServerTiming( result ) {
+export function getResultServerTiming( percentiles, result ) {
 	const runs = getResultRuns_( result );
 	if ( ! getServerTimingHeader ) {
 		getServerTimingHeader = createGetResponseHeader_( 'Server-Timing' );
@@ -288,7 +293,6 @@ export function getResultServerTiming( result ) {
 		const name = stValue.substring( 0, sepIndex );
 		metrics[ name ] = {
 			name,
-			median: 0,
 			runs: [],
 		};
 	} );
@@ -314,9 +318,10 @@ export function getResultServerTiming( result ) {
 			throw new Error( `Invalid Server-Timing header: Metric ${ metric.name } not present in every run` );
 		}
 
-		return {
-			...metric,
-			median: calcMedian( metric.runs ),
-		};
+		const data = { ...metric };
+		percentiles.forEach( ( percentile ) => {
+			data[ `p${ percentile }` ] = calcPercentile( percentile, metric.runs );
+		} );
+		return data;
 	} );
 }


### PR DESCRIPTION
Follow up to #40.

This PR chooses a hard-coded set of percentiles 10, 25, 50 (median), 75, 90, previously discussed with @oandregal. This is also what is commonly used for HTTP Archive queries by that team, and we have also used that set of percentiles in our own HTTP Archive queries (e.g. [this one](https://github.com/GoogleChromeLabs/wpp-research/blob/8f7763f964ae4a05a78e9b84877f66877f6e6410/sql/2023/01/external-deferred-scripts-distribution.sql#L25)).

In the future we can maybe make the concrete percentiles controllable by the argument, but that doesn't seem necessary at this point. The above percentiles are a good baseline to get a more representative impression of the overall accuracy of the values.

### Testing this PR

1. Run each of the 4 commands prior to this change (for any URL / any WebPageTest result).
2. Switch to this PR branch.
3. Run the same commands as above again.
    * For the `wpt-*` commands, make sure the median results are the same.
    * For the `benchmark-*` commands, make sure the median results are roughly similar (they won't be the same because it's different runs).
4. Run the same commands again, but now include the `--show-percentiles` flag in each one.
    * For the `wpt-*` commands, make sure the `p50` results are the same as the previous median results.
    * For the `benchmark-*` commands, make sure the `p50` results are roughly similar to the previous median results (they won't be the same because it's different runs).
    * For any command, do a quick sanity check on whether percentile values look right, e.g. if you use 8 runs for your command, the `p25` value should be the value of the 2nd lowest run result, or if you use 10 runs, the `p90` value should be the 9th lowest / 2nd highest run result. This sanity check can be done for any of the commands, since the underlying percentile calculation logic is the same in all of them.