### PR TITLE
Top lazy loaded LCP image class names

### DIFF
--- a/sql/2023/03/top-lazy-lcp-class-names.sql
+++ b/sql/2023/03/top-lazy-lcp-class-names.sql
@@ -1,0 +1,71 @@
+CREATE TEMP FUNCTION getAttr(attributes STRING, attribute STRING) RETURNS STRING LANGUAGE js AS '''
+  try {
+    const data = JSON.parse(attributes);
+    const attr = data.find(attr => attr["name"] === attribute)
+    return attr.value
+  } catch (e) {
+    return null;
+  }
+''';
+
+WITH lazypress AS (
+  SELECT
+    page,
+    getAttr(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes'), 'loading') = 'lazy' AS native_lazy,
+    getAttr(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes'), 'class') AS class,
+    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.nodeName') = 'IMG' AS img_lcp
+  FROM
+    `httparchive.all.pages`,
+    UNNEST(technologies) AS t
+  WHERE
+    date = '2023-02-01' AND
+    client = 'desktop' AND 
+    is_root_page AND
+    t.technology = 'WordPress'
+),
+
+totals AS (
+  SELECT
+    COUNT(DISTINCT page) AS total
+  FROM
+    lazypress
+  WHERE
+    native_lazy
+),
+
+classes AS (
+  SELECT
+    class,
+    ARRAY_AGG(DISTINCT page LIMIT 3) sample_pages,
+    COUNT(0) AS freq,
+    COUNT(DISTINCT page) AS pages,
+    SUM(COUNT(0)) OVER () AS total,
+    COUNT(0) / SUM(COUNT(0)) OVER () AS pct
+  FROM
+    lazypress,
+    UNNEST(REGEXP_EXTRACT_ALL(class, r'([^\s]+)')) AS class
+  WHERE
+    native_lazy
+  GROUP BY
+    class
+)
+
+
+SELECT
+  class,
+  freq,
+  classes.total,
+  pct,
+  pages,
+  totals.total AS total_pages,
+  pages / totals.total AS pct_pages,
+  sample_pages[OFFSET(0)] AS sample_page_1,
+  sample_pages[OFFSET(1)] AS sample_page_2,
+  sample_pages[OFFSET(2)] AS sample_page_3
+FROM
+  classes,
+  totals
+ORDER BY
+  pages DESC
+LIMIT
+  50

--- a/sql/2023/03/top-lazy-lcp-class-names.sql
+++ b/sql/2023/03/top-lazy-lcp-class-names.sql
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/45
 CREATE TEMP FUNCTION getAttr(attributes STRING, attribute STRING) RETURNS STRING LANGUAGE js AS '''
   try {
     const data = JSON.parse(attributes);

--- a/sql/2023/03/top-lazy-lcp-class-names.sql
+++ b/sql/2023/03/top-lazy-lcp-class-names.sql
@@ -1,3 +1,18 @@
+# HTTP Archive query to get top class names used on lazy loaded LCP images.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 CREATE TEMP FUNCTION getAttr(attributes STRING, attribute STRING) RETURNS STRING LANGUAGE js AS '''
   try {
     const data = JSON.parse(attributes);

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,9 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/03
+* [Top class names used on lazy loaded LCP images](./2023/03/top-lazy-lcp-class-names.sql)
+
 ### 2023/01
 
 * [% of WordPress sites that lazy-load their LCP image](./2023/01/lazyloaded-lcp-opportunity.sql)


### PR DESCRIPTION
<details>
<summary>Query results</summary>

class | freq | total | pct | pages | total_pages | pct_pages | sample_page_1 | sample_page_2 | sample_page_3
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
wp-post-image | 128,298 | 911,904 | 14.1% | 127,897 | 369,933 | 34.6% | https://euroforia.net/ | https://ppdtp.com/ | https://vintage-speaker-review.com/
attachment-full | 68,752 | 911,904 | 7.5% | 68,734 | 369,933 | 18.6% | https://scantoolpro.com/ | https://city-camera.com/ | https://skinxmed.de/
size-full | 63,419 | 911,904 | 7.0% | 63,419 | 369,933 | 17.1% | https://motoline.it/ | https://www.drakauc.com/ | https://www.aryasentraconsulting.com/
size-large | 39,197 | 911,904 | 4.3% | 39,197 | 369,933 | 10.6% | http://pgm.skaw.pl/ | https://edge-forex.com/ | https://www.tuescalera.co/
attachment-large | 39,076 | 911,904 | 4.3% | 39,063 | 369,933 | 10.6% | https://acsenda.com/ | https://bustimetable.lk/ | https://hobbyaescala.com/
lazyloaded | 22,930 | 911,904 | 2.5% | 22,930 | 369,933 | 6.2% | https://www.gifs-porno.com/ | https://www.zukiworld.com/ | https://englishsir.ru/
vc_single_image-img | 16,151 | 911,904 | 1.8% | 16,151 | 369,933 | 4.4% | https://www.ccab.cl/ | https://avondale-foods.co.uk/ | https://bearn-bigorre.cmcas.com/
attachment-post-thumbnail | 11,193 | 911,904 | 1.2% | 11,193 | 369,933 | 3.0% | https://tufting-gun.dk/ | https://pekcraft.com/ | https://www.ipd.uw.edu/
size-post-thumbnail | 11,108 | 911,904 | 1.2% | 11,108 | 369,933 | 3.0% | https://consorciosph.wordpress.com/ | https://cityzenmobility.fr/ | https://breakfastographer.wordpress.com/
aligncenter | 9,045 | 911,904 | 1.0% | 9,044 | 369,933 | 2.4% | https://megafonme.ru/ | https://cocinalh.es/ | https://otdyhsamostoyatelno.ru/
size-medium | 8,367 | 911,904 | 0.9% | 8,367 | 369,933 | 2.3% | https://ciarts.es/ | https://colombiatributa.com/ | https://telangananotes.com/
ls-bg | 7,061 | 911,904 | 0.8% | 7,061 | 369,933 | 1.9% | https://metaprovence.co.kr/ | https://www.theserpentrooms.co.uk/ | https://thecheesemakingworkshop.com.au/
attachment-woocommerce_thumbnail | 7,041 | 911,904 | 0.8% | 7,041 | 369,933 | 1.9% | https://vqtshirt.com/ | https://www.betterlifekart.com/ | https://www.hardcopy.co.za/
size-woocommerce_thumbnail | 7,038 | 911,904 | 0.8% | 7,038 | 369,933 | 1.9% | https://marocshop.shop/ | https://tezro.ru/ | https://techmeaway.com.au/
size-medium_large | 6,950 | 911,904 | 0.8% | 6,950 | 369,933 | 1.9% | https://www.redesdenoticias.com.ar/ | https://asnes-academy.com/ | https://authorcafe.com/
attachment-medium_large | 6,938 | 911,904 | 0.8% | 6,938 | 369,933 | 1.9% | https://aceqlaboratorios.com.co/ | https://tokyo-in-pics.com/ | https://www.quotidianoaudio.it/
alignnone | 6,924 | 911,904 | 0.8% | 6,924 | 369,933 | 1.9% | https://www.portalclub.es/ | https://cameronwebb.wordpress.com/ | https://collegeofcos.com/
attachment-medium | 6,821 | 911,904 | 0.7% | 6,820 | 369,933 | 1.8% | https://kehillah.org.uk/ | https://kit-survie.org/ | https://kasiorder.shop/
entry-card-thumb-image | 6,061 | 911,904 | 0.7% | 6,061 | 369,933 | 1.6% | https://kkkkblog.com/ | https://hagureblog.com/ | https://table-camp.com/
card-thumb-image | 5,786 | 911,904 | 0.6% | 5,786 | 369,933 | 1.6% | https://soccer-mirunara.com/ | https://kanapappa.com/ | https://messagewoeigode.com/
size-original | 5,619 | 911,904 | 0.6% | 5,619 | 369,933 | 1.5% | https://pineapplesupply.com.br/ | https://www.ratiowatches.com/ | https://institutosuperacao.org/
attachment-original | 5,617 | 911,904 | 0.6% | 5,617 | 369,933 | 1.5% | https://suckhoeduongruot.com/ | https://haisan24h.com.vn/ | https://chico.com.vn/
entered | 5,454 | 911,904 | 0.6% | 5,454 | 369,933 | 1.5% | https://dumadistyle.com/ | https://antenadigitalsat.ro/ | https://www.ziarulprofit.ro/
image | 5,332 | 911,904 | 0.6% | 5,332 | 369,933 | 1.4% | https://wandelenenreizen.nl/ | https://www.ranbhumi.com/ | http://www.laotrarevista.com/
lazy-loaded | 4,776 | 911,904 | 0.5% | 4,774 | 369,933 | 1.3% | https://www.myfavoritetaverns.com/ | https://turezurenaru-zakki.com/ | https://b44.ru/
img-responsive | 4,146 | 911,904 | 0.5% | 4,131 | 369,933 | 1.1% | https://hockeybelgium.lesoir.be/ | https://www.italianfuturism.org/ | http://www.sportautonapoli.com/
lazyautosizes | 3,985 | 911,904 | 0.4% | 3,985 | 369,933 | 1.1% | http://idle-life.info/ | https://dailyrituals.de/ | https://wisetoast.com/
tp-rs-img | 3,888 | 911,904 | 0.4% | 3,888 | 369,933 | 1.1% | https://www.faculdadefamap.edu.br/ | https://bimai.es/ | https://www.autismspeaks.ca/
litespeed-loaded | 3,714 | 911,904 | 0.4% | 3,714 | 369,933 | 1.0% | https://www.mooiverouderen.com/ | https://zonaminecraft.net/ | https://www.pnc-contact.com/
fl-photo-img | 3,583 | 911,904 | 0.4% | 3,583 | 369,933 | 1.0% | https://cityoval.com.au/ | https://www.ontspanthuis.nl/ | https://www.physiomira.com/
size-colormag-featured-image | 3,576 | 911,904 | 0.4% | 3,576 | 369,933 | 1.0% | https://mediul24.ro/ | https://labakademi.com/ | https://timojesh.net/
attachment-colormag-featured-image | 3,576 | 911,904 | 0.4% | 3,576 | 369,933 | 1.0% | https://conservativeus.com/ | https://cronicavj.ro/ | https://luginalajm.com/
entry-image | 3,474 | 911,904 | 0.4% | 3,474 | 369,933 | 0.9% | https://flowerintheweeds.com/ | https://www.sometimescrafty.com/ | https://showseason.com/
wp-block-cover__image-background | 3,355 | 911,904 | 0.4% | 3,355 | 369,933 | 0.9% | https://computersfortheblind.org/ | https://insel-lieben.de/ | https://hdtransaxle.com/
rs-lazyload | 3,199 | 911,904 | 0.4% | 3,199 | 369,933 | 0.9% | https://registroycontrol.ustatunja.edu.co/ | https://xn--o3cngegcmx9eq2a2d7h.com/ | https://www.aorticsurgery.it/
attachment-slider | 2,485 | 911,904 | 0.3% | 2,485 | 369,933 | 0.7% | https://www.zupa-bezgresnog-zaceca-bdm.hr/ | https://www.camping-car.eu.com/ | https://iut-thionville-yutz.univ-lorraine.fr/
size-slider | 2,344 | 911,904 | 0.3% | 2,344 | 369,933 | 0.6% | http://zenithnovels.com/ | https://www.cografyabank.com/ | https://fizika.pmf.ni.ac.rs/
lazy-load-active | 2,314 | 911,904 | 0.3% | 2,314 | 369,933 | 0.6% | https://familie-kokkenet.dk/ | https://olfa.vn/ | http://kyunglab.vn/
lazy | 2,261 | 911,904 | 0.2% | 2,258 | 369,933 | 0.6% | https://www.biopetroclean.com/ | https://www.ekitaplaroku.com/ | https://naritoku.com/
loaded | 2,228 | 911,904 | 0.2% | 2,228 | 369,933 | 0.6% | https://entirelyhealth.com/ | https://p3solutionsblog.com/ | https://tbsgraduates.net/
img-fluid | 2,192 | 911,904 | 0.2% | 2,173 | 369,933 | 0.6% | https://vdkr.org/ | https://www.bayhilleyecare.com/ | https://www.new-marske-harriers.co.uk/
soliloquy-image | 2,131 | 911,904 | 0.2% | 2,131 | 369,933 | 0.6% | https://downtowndurham.com/ | https://rathfarnhamparish.ie/ | https://thirdeyecomics.com/
attachment-post | 2,095 | 911,904 | 0.2% | 2,095 | 369,933 | 0.6% | https://www.exploremindfully.com/ | https://heathershomebakery.com/ | https://gaiacozzi.com/
soliloquy-image-1 | 1,998 | 911,904 | 0.2% | 1,998 | 369,933 | 0.5% | https://www.coolcovers.co.uk/ | https://smith.agrilife.org/ | https://mec.vic.edu.au/
slide | 1,955 | 911,904 | 0.2% | 1,954 | 369,933 | 0.5% | https://deck655.com/ | https://caringfornaturalhair.com/ | https://www.jeffchanemouyephotography.com/
tc-smart-loaded | 1,888 | 911,904 | 0.2% | 1,888 | 369,933 | 0.5% | https://fourgatesofgloucester.co.uk/ | https://www.pinocchio-montesicuro.it/ | https://www.byte-post.com/
size-small_size | 1,807 | 911,904 | 0.2% | 1,807 | 369,933 | 0.5% | https://chamilog.com/ | https://www.summy-antiquecoins.blog/ | https://rockmancapture.site/
attachment-small_size | 1,805 | 911,904 | 0.2% | 1,805 | 369,933 | 0.5% | https://sukidesu-sapporo.com/ | https://motor.xbiz.jp/ | https://bi-bi-bi.tw/
skip-lazy | 1,781 | 911,904 | 0.2% | 1,781 | 369,933 | 0.5% | https://www.itfnet.org/ | https://bahlconsult.com/ | https://www.northdetectingevents.co.uk/
lazyload | 1,717 | 911,904 | 0.2% | 1,714 | 369,933 | 0.5% | https://blog.systoolsgroup.com/ | https://snacksandsips.com/ | https://nghethanhca.com/

</details>