### PR TITLE
Add LCP minus TTFB as a metric to `benchmark-web-vitals`, using new logic for aggregate metrics

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -150,7 +150,7 @@ benchmark-server-timing -f path/to/urls.txt -n 5
 
 ### `benchmark-web-vitals`
 
-Loads the provided URLs in a headless browser several times to measure median Web Vitals metrics for each URL. Currently the results cover load time metrics FCP, LCP, and TTFB, as well as the aggregate metric "LCP - TTFB", which is useful to assess client-side performance specifically. Including additional metrics is explored in a [follow up pull request](https://github.com/GoogleChromeLabs/wpp-research/pull/41).
+Loads the provided URLs in a headless browser several times to measure median Web Vitals metrics for each URL. Currently the results cover load time metrics FCP, LCP, and TTFB, as well as the aggregate metric "LCP-TTFB", which is useful to assess client-side performance specifically. Including additional metrics is explored in a [follow up pull request](https://github.com/GoogleChromeLabs/wpp-research/pull/41).
 
 #### Arguments
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -150,7 +150,7 @@ benchmark-server-timing -f path/to/urls.txt -n 5
 
 ### `benchmark-web-vitals`
 
-Loads the provided URLs in a headless browser several times to measure median Web Vitals metrics for each URL. Currently the results cover load time metrics FCP, LCP, and TTFB. Including additional metrics is explored in a [follow up pull request](https://github.com/GoogleChromeLabs/wpp-research/pull/41).
+Loads the provided URLs in a headless browser several times to measure median Web Vitals metrics for each URL. Currently the results cover load time metrics FCP, LCP, and TTFB, as well as the aggregate metric "LCP - TTFB", which is useful to assess client-side performance specifically. Including additional metrics is explored in a [follow up pull request](https://github.com/GoogleChromeLabs/wpp-research/pull/41).
 
 #### Arguments
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -206,41 +206,52 @@ async function benchmarkURL( browser, params ) {
 		}
 	} );
 
-	Object.entries( aggregateMetricsDefinition ).forEach( ( [ key, value ] ) => {
-		// Bail if any of the necessary partial metrics are not provided.
-		const partialMetrics = [ ...( value.add || [] ), ...( value.subtract || [] ) ];
-		if ( ! partialMetrics.length ) {
-			return;
-		}
-		for ( const metricKey of partialMetrics ) {
-			if ( ! metrics[ metricKey ] ) {
+	Object.entries( aggregateMetricsDefinition ).forEach(
+		( [ key, value ] ) => {
+			// Bail if any of the necessary partial metrics are not provided.
+			const partialMetrics = [
+				...( value.add || [] ),
+				...( value.subtract || [] ),
+			];
+			if ( ! partialMetrics.length ) {
 				return;
 			}
-		}
+			for ( const metricKey of partialMetrics ) {
+				if ( ! metrics[ metricKey ] ) {
+					return;
+				}
+			}
 
-		// Initialize all values for the metric as 0.
-		metrics[ key ] = [];
-		const numResults = value.add ? metrics[ value.add[ 0 ] ].length : metrics[ value.subtract[ 0 ] ].length;
-		for ( let n = 0; n < numResults; n++ ) {
-			metrics[ key ].push( 0.0 );
-		}
+			// Initialize all values for the metric as 0.
+			metrics[ key ] = [];
+			const numResults = value.add
+				? metrics[ value.add[ 0 ] ].length
+				: metrics[ value.subtract[ 0 ] ].length;
+			for ( let n = 0; n < numResults; n++ ) {
+				metrics[ key ].push( 0.0 );
+			}
 
-		// Add and subtract all values.
-		if ( value.add ) {
-			value.add.forEach( ( metricKey ) => {
-				metrics[ metricKey ].forEach( ( metricValue, metricIndex ) => {
-					metrics[ key ][ metricIndex ] += metricValue;
+			// Add and subtract all values.
+			if ( value.add ) {
+				value.add.forEach( ( metricKey ) => {
+					metrics[ metricKey ].forEach(
+						( metricValue, metricIndex ) => {
+							metrics[ key ][ metricIndex ] += metricValue;
+						}
+					);
 				} );
-			} );
-		}
-		if ( value.subtract ) {
-			value.subtract.forEach( ( metricKey ) => {
-				metrics[ metricKey ].forEach( ( metricValue, metricIndex ) => {
-					metrics[ key ][ metricIndex ] -= metricValue;
+			}
+			if ( value.subtract ) {
+				value.subtract.forEach( ( metricKey ) => {
+					metrics[ metricKey ].forEach(
+						( metricValue, metricIndex ) => {
+							metrics[ key ][ metricIndex ] -= metricValue;
+						}
+					);
 				} );
-			} );
+			}
 		}
-	} );
+	);
 
 	return { completeRequests, metrics };
 }

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -131,6 +131,17 @@ async function benchmarkURL( browser, params ) {
 		},
 	};
 
+	/*
+	 * Aggregate metrics are metrics which are calculated for every request as
+	 * a combination of other metrics.
+	 */
+	const aggregateMetricsDefinition = {
+		'LCP - TTFB': {
+			add: [ 'LCP' ],
+			subtract: [ 'TTFB' ],
+		},
+	};
+
 	let completeRequests = 0;
 	let requestNum = 0;
 
@@ -192,6 +203,42 @@ async function benchmarkURL( browser, params ) {
 	Object.entries( metricsDefinition ).forEach( ( [ key, value ] ) => {
 		if ( value.results.length ) {
 			metrics[ key ] = value.results;
+		}
+	} );
+
+	Object.entries( aggregateMetricsDefinition ).forEach( ( [ key, value ] ) => {
+		// Bail if any of the necessary partial metrics are not provided.
+		const partialMetrics = [ ...( value.add || [] ), ...( value.subtract || [] ) ];
+		if ( ! partialMetrics.length ) {
+			return;
+		}
+		for ( const metricKey of partialMetrics ) {
+			if ( ! metrics[ metricKey ] ) {
+				return;
+			}
+		}
+
+		// Initialize all values for the metric as 0.
+		metrics[ key ] = [];
+		const numResults = value.add ? metrics[ value.add[ 0 ] ].length : metrics[ value.subtract[ 0 ] ].length;
+		for ( let n = 0; n < numResults; n++ ) {
+			metrics[ key ].push( 0.0 );
+		}
+
+		// Add and subtract all values.
+		if ( value.add ) {
+			value.add.forEach( ( metricKey ) => {
+				metrics[ metricKey ].forEach( ( metricValue, metricIndex ) => {
+					metrics[ key ][ metricIndex ] += metricValue;
+				} );
+			} );
+		}
+		if ( value.subtract ) {
+			value.subtract.forEach( ( metricKey ) => {
+				metrics[ metricKey ].forEach( ( metricValue, metricIndex ) => {
+					metrics[ key ][ metricIndex ] -= metricValue;
+				} );
+			} );
 		}
 	} );
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -136,7 +136,7 @@ async function benchmarkURL( browser, params ) {
 	 * a combination of other metrics.
 	 */
 	const aggregateMetricsDefinition = {
-		'LCP - TTFB': {
+		'LCP-TTFB': {
 			add: [ 'LCP' ],
 			subtract: [ 'TTFB' ],
 		},


### PR DESCRIPTION
This PR adds the "LCP - TTFB" metric, which is useful to assess client-side performance specifically, to the `benchmark-web-vitals` command.

Having this metric will allow us to get a more granular breakdown for client-side performance impact of a change when using this command. Note that without having this metric as part of the command, of course we could still subtract median TTFB from median LCP, but that would not necessarily give the same result, and it would most importantly be statistically incorrect. The right way is to compute this value for every single request, and then use the median of those values, which is what this PR enables.