### PR TITLE
Add query to assess lazy-loading usage for WP sites that should have the feature

### DIFF
--- a/sql/2023/04/image-lazy-loading-usage.sql
+++ b/sql/2023/04/image-lazy-loading-usage.sql
@@ -1,0 +1,46 @@
+# HTTP Archive query to get the number of WordPress sites on version >= 5.5 that use any images and lazy-load them.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/51
+CREATE TEMPORARY FUNCTION get_image_loading_attributes(images_string STRING)
+RETURNS ARRAY<STRUCT<loading STRING>>
+LANGUAGE js AS '''
+var result = [];
+try {
+  var images = JSON.parse(images_string);
+  for (const img of images){
+    result.push({
+      loading: img.loading
+    })
+  }
+} catch (e) {}
+return result;
+''';
+
+SELECT
+  _TABLE_SUFFIX AS client,
+  COUNT(DISTINCT url) AS urls_with_images,
+  COUNT(DISTINCT IF (loading = 'lazy', url, NULL)) AS urls_with_loading_lazy
+FROM
+  `httparchive.pages.2023_03_01_*`,
+  UNNEST(get_image_loading_attributes(JSON_EXTRACT_SCALAR(payload, '$._Images'))) AS image_loading
+WHERE
+  JSON_EXTRACT(payload, '$._detected_apps.WordPress') IS NOT NULL
+  AND (CAST(REGEXP_EXTRACT(JSON_EXTRACT(payload, '$._detected_apps.WordPress'), r'^"(\d+\.\d+)') AS FLOAT64) >= 5.5)
+GROUP BY
+  client
+ORDER BY
+  client ASC

--- a/sql/2023/04/image-lazy-loading-usage.sql
+++ b/sql/2023/04/image-lazy-loading-usage.sql
@@ -33,7 +33,8 @@ return result;
 SELECT
   _TABLE_SUFFIX AS client,
   COUNT(DISTINCT url) AS urls_with_images,
-  COUNT(DISTINCT IF (loading = 'lazy', url, NULL)) AS urls_with_loading_lazy
+  COUNT(DISTINCT IF (loading = 'lazy', url, NULL)) AS urls_with_loading_lazy,
+  COUNT(DISTINCT IF (loading = 'lazy', url, NULL)) / COUNT(DISTINCT url) AS pct_with_loading_lazy
 FROM
   `httparchive.pages.2023_03_01_*`,
   UNNEST(get_image_loading_attributes(JSON_EXTRACT_SCALAR(payload, '$._Images'))) AS image_loading

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,7 +18,12 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/04
+
+* [Number of WordPress sites on version >= 5.5 that use any images and lazy-load them](./2023/04/image-lazy-loading-usage.sql)
+
 ### 2023/03
+
 * [Top class names used on lazy loaded LCP images](./2023/03/top-lazy-lcp-class-names.sql)
 * [% of WordPress sites that do not implement Critical CSS via custom metrics](./2023/03/critical-css-opportunity-custom-metrics.sql)
 * [% of WordPress sites that do not implement Critical CSS via custom metrics (using `$._renderBlockingCSS`)](./2023/03/critical-css-opportunity-custom-metrics-alternative.sql)


### PR DESCRIPTION
This query explores how many WordPress sites >= 5.5 lazy-load any of their images. The background for that query is that we would like to get a better idea of how many WordPress sites that technically have the feature available do not use it, e.g. have it explicitly disabled.

## Query results

Row | client | urls_with_images | urls_with_loading_lazy | pct_with_loading_lazy
-- | -- | -- | -- | --
1 | desktop | 2483598 | 1546146 | 0.6225427787
2 | mobile | 3265631 | 2050648 | 0.6279484731

Based on March 2023 dataset