### PR TITLE
Prevent navigating away while benchmarking

### DIFF
--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -176,9 +176,10 @@ async function benchmarkURL( browser, params ) {
 				 * Do a random click, since only that triggers certain metrics
 				 * like LCP, as only a user interaction stops reporting new LCP
 				 * entries. See https://web.dev/lcp/.
+				 *
+				 * Click off screen to prevent clicking a link by accident and navigating away.
 				 */
-				await page.click( 'body' );
-
+				await page.click( 'body', { offset: { x: -500, y: -500 } } );
 				// Get the metric value from the global.
 				const metric = await page.evaluate( value.get );
 				value.results.push( metric );


### PR DESCRIPTION
When running the web vitals benchmark the click action may click a link by accident. [Puppeteer clicks the center of the element by default](https://pptr.dev/api/puppeteer.page.click).  
When this happens, Puppeteer cannot evaluate the metrics. Instead this error is thrown: `Error: Execution context was destroyed, most likely because of a navigation.` ([which is silently ignored](https://github.com/GoogleChromeLabs/wpp-research/blob/331bdc504e67111613e8ce724468187397c6a9b1/cli/commands/benchmark-web-vitals.mjs#L187)) and the results are `undefined`.
![image](https://user-images.githubusercontent.com/5352634/235164576-25a31b93-30b3-413e-9b60-6a5bbb02c835.png)

By giving the click action a negative offset the odds of clicking a link are greatly reduced. I suppose there could still be off-screen elements like skiplinks, but I don't expect to see anything at -500,-500.


