### PR TITLE
Implement query to get block theme adoption based on new HTTP Archive custom metric

### DIFF
--- a/sql/2023/05/block-theme-usage-custom-metrics.sql
+++ b/sql/2023/05/block-theme-usage-custom-metrics.sql
@@ -26,6 +26,7 @@ FROM
 WHERE
   date = "2023-04-01"
   AND technology.technology = "WordPress"
+  AND is_root_page = true
 GROUP BY
   client
 ORDER BY

--- a/sql/2023/05/block-theme-usage-custom-metrics.sql
+++ b/sql/2023/05/block-theme-usage-custom-metrics.sql
@@ -1,0 +1,32 @@
+# HTTP Archive query to get % WordPress sites using a block theme via custom metrics.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/53
+SELECT
+  client,
+  COUNT(DISTINCT page) AS total_wp_sites,
+  COUNT(DISTINCT IF(CAST(JSON_EXTRACT_SCALAR(custom_metrics, "$.cms.wordpress.block_theme") AS BOOL), page, null)) AS with_block_theme,
+  COUNT(DISTINCT IF(CAST(JSON_EXTRACT_SCALAR(custom_metrics, "$.cms.wordpress.block_theme") AS BOOL), page, null)) / COUNT(DISTINCT page) AS pct_total
+FROM
+  `httparchive.all.pages`,
+  UNNEST(technologies) AS technology
+WHERE
+  date = "2023-04-01"
+  AND technology.technology = "WordPress"
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,10 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/05
+
+* [% WordPress sites using a block theme via custom metrics](./2023/05/block-theme-usage-custom-metrics.sql)
+
 ### 2023/04
 
 * [Number of WordPress sites on version >= 5.5 that use any images and lazy-load them](./2023/04/image-lazy-loading-usage.sql)


### PR DESCRIPTION
This query has the same purpose as the one implemented in #32, however it uses the HTTP Archive custom metric added in https://github.com/HTTPArchive/custom-metrics/pull/62, which has been available in HTTP Archive datasets starting with March 2023.

This custom metric makes the query (which was extremely slow before as it had to parse entire response bodies) notably faster (in a comparison 3:33 minutes vs 35:49 minutes).

## Query results

Row | client | total_wp_sites | with_block_theme | pct_total
-- | -- | -- | -- | --
1 | desktop | 4519655 | 31102 | 0.0068814986984626035
2 | mobile | 5829541 | 43403 | 0.00744535461711308

Based on April 2023 dataset

### Comparison with old query

For reference, to assess the new numbers and performance of the query, the query from #32 was also run again for the April 2023 dataset. Here are the results:

Row | client | with_block_theme | total_wp_sites | pct_total | wp_gte_59  
-- | -- | -- | -- | -- | -- 
1 | desktop | 12669 | 4506581 | 0.002811222077224397 | 3810151
2 | mobile | 19992 | 5825503 | 0.0034318066611587015 | 

This shows slightly lower percentages, likely because the query's approach of parsing the HTML from the response bodies is more error-prone.