### PR TITLE
XHProf: Only override modified docker compose values

### DIFF
--- a/tools/xhprof/docker-compose.override.yml
+++ b/tools/xhprof/docker-compose.override.yml
@@ -1,53 +1,13 @@
-version: '3.7'
-
 services:
-
-  ##
-  # The web server container.
-  ##
-  wordpress-develop:
-    image: nginx:alpine
-
-    networks:
-      - wpdevnet
-
-    ports:
-      - ${LOCAL_PORT-8889}:80
-
-    environment:
-      LOCAL_DIR: ${LOCAL_DIR-src}
-
-    volumes:
-      - ./tools/local-env/default.template:/etc/nginx/conf.d/default.template
-      - ./:/var/www
-
-    # Load our config file, substituting environment variables into the config.
-    command: /bin/sh -c "envsubst '$$LOCAL_DIR' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"
-
-    depends_on:
-      - php
 
   ##
   # The PHP container.
   ##
   php:
     image: spacedmonkey/php-xhprof:${LOCAL_PHP-latest}
-    networks:
-      - wpdevnet
-
-    environment:
-      - LOCAL_PHP_XDEBUG=${LOCAL_PHP_XDEBUG-false}
-      - LOCAL_PHP_MEMCACHED=true
-      - PHP_FPM_UID=${PHP_FPM_UID-1000}
-      - PHP_FPM_GID=${PHP_FPM_GID-1000}
-
-    volumes:
-      - ./tools/local-env/php-config.ini:/usr/local/etc/php/conf.d/php-config.ini
-      - ./:/var/www
 
     depends_on:
       - mysql
-      - memcached
       - xhgui
 
   xhgui:
@@ -76,62 +36,9 @@ services:
       - "27017:27017"
     networks:
       - wpdevnet
-  ##
-  # The MySQL container.
-  ##
-  mysql:
-    image: ${LOCAL_DB_TYPE-mysql}:${LOCAL_DB_VERSION-latest}
-
-    networks:
-      - wpdevnet
-
-    ports:
-      - "3306"
-
-    environment:
-      MYSQL_ROOT_PASSWORD: password
-
-    volumes:
-      - ./tools/local-env/mysql-init.sql:/docker-entrypoint-initdb.d/mysql-init.sql
-      - mysql:/var/lib/mysql
-
-    # For compatibility with PHP versions that don't support the caching_sha2_password auth plugin used in MySQL 8.0.
-    command: --default-authentication-plugin=mysql_native_password
-
-  ##
-  # The WP CLI container.
-  ##
-  cli:
-    image: wordpressdevelop/cli:${LOCAL_PHP-latest}
-
-    networks:
-      - wpdevnet
-
-    environment:
-      - LOCAL_PHP_XDEBUG=${LOCAL_PHP_XDEBUG-false}
-      - LOCAL_PHP_MEMCACHED=true
-      - PHP_FPM_UID=${PHP_FPM_UID-1000}
-      - PHP_FPM_GID=${PHP_FPM_GID-1000}
-
-    volumes:
-      - ./:/var/www
-
-    # The init directive ensures the command runs with a PID > 1, so Ctrl+C works correctly.
-    init: true
-
-  memcached:
-    image: memcached
-
-    networks:
-      - wpdevnet
 
 volumes:
   # So that sites aren't wiped every time containers are restarted, MySQL uses a persistent volume.
   mysql: {}
   webroot-share:
   mongodb:
-
-networks:
-  # Creating our own network allows us to connect between containers using their service name.
-  wpdevnet:
-    driver: bridge


### PR DESCRIPTION
This edits the `docker-compose.override.yml` file so only the modified values are included. This ensures that all other values rely on the main `docker-compose.yml` values set in the core repo.

See: https://github.com/WordPress/wordpress-develop/blob/trunk/docker-compose.yml