### PR TITLE
Update benchmark-web-vitals to allow connection to existing browser instance (e.g. on mobile device)

### DIFF
--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -63,7 +63,19 @@ export const options = [
 		description:
 			'Whether to show more granular percentiles instead of only the median',
 	},
+	{
+		argname: '-c, --connect <browserWSEndpoint>',
+		description: 'Connect to an existing browser instance',
+	},
 ];
+
+async function getBrowser( opt ) {
+	return opt.connect
+		? puppeteer.connect( {
+			browserWSEndpoint: opt.connect,
+		} )
+		: puppeteer.launch();
+}
 
 export async function handler( opt ) {
 	if ( ! isValidTableFormat( opt.output ) ) {
@@ -78,7 +90,7 @@ export async function handler( opt ) {
 	const { number: amount } = opt;
 	const results = [];
 
-	const browser = await puppeteer.launch();
+	const browser = await getBrowser( opt );
 
 	for await ( const url of getURLs( opt ) ) {
 		const { completeRequests, metrics } = await benchmarkURL( browser, {

--- a/cli/run.mjs
+++ b/cli/run.mjs
@@ -61,7 +61,8 @@ const catchException = ( handler ) => {
 		try {
 			await handler( ...args );
 		} catch ( error ) {
-			log( formats.error( error ) );
+			log( formats.error( `Error: ${ error.message }` ) );
+			console.error( error ); // eslint-disable-line no-console
 			process.exitCode = 1;
 		}
 	};


### PR DESCRIPTION
This introduces a new `--connect`/`-c` option which causes [`puppeteer.connect()`](https://pptr.dev/api/puppeteer.puppeteernode.connect) to be used instead of `puppeteer.launch()`. This is intended to allow benchmark-web-vitals to run on an existing browser instance, such as on a mobile device:

```bash
npm run research -- benchmark-web-vitals -u http://example.com -n 1 -p --connect 'ws://127.0.0.1:9222/devtools/browser'
```

Nevertheless, I've not gotten this to work yet. The process hangs at the call to `puppeteer.connect()` and I'm not sure why.

Here is how I set up my environment to test. (See also [Remote debug Android devices](https://developer.chrome.com/docs/devtools/remote-debugging/).)

1. Obtain Android phone
2. [Enable Developer Options](https://developer.android.com/studio/debug/dev-options)
3. Enable USB Debugging in Developer Options
4. Connect phone to computer.
7. On phone, a "Allow USB debugging?" dialog will appear. Tap Allow.
6. If using ChromeOS, click "Connect to Linux" in the "USB device detected" dialog.
8. On computer, make sure that `adb` (Android Debug Studio) is installed. (In Linux, `sudo apt-get install adb`.)
9. On computer, open terminal and run: `adb forward tcp:9222 localabstract:chrome_devtools_remote`

At this point, when you go to `chrome://inspect/#devices` on your computer, you should see the Android phone connected:

> ![image](https://github.com/GoogleChromeLabs/wpp-research/assets/134745/51b67ec1-83bb-4393-996c-8b83c4aa8aaa)

Note the **Remote Target** entry seems to be a mirror of the other target (here **Pixel 5**) which shows up once you do `adb forward`.

At this point as well, you should be able to tap on the **inspect** link for one of the Chrome tabs listed and get the DevTools opened for that tab:

> ![image](https://github.com/GoogleChromeLabs/wpp-research/assets/134745/66b356f7-aee8-4180-bac4-ccfcbd89de60)

On your computer, you should be able to un `curl http://localhost:9222/json/version` and get something like:

```json
{
   "Android-Package": "com.android.chrome",
   "Browser": "Chrome/115.0.5790.136",
   "Protocol-Version": "1.3",
   "User-Agent": "Mozilla/5.0 (Linux; Android 10; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Mobile Safari/537.36",
   "V8-Version": "11.5.150.16",
   "WebKit-Version": "537.36 (@85c2a5a25b8821a0e33a48fae903d4e80c8067cd)",
   "webSocketDebuggerUrl": "ws://localhost:9222/devtools/browser"
}
```

Take note of the `webSocketDebuggerUrl`. This is the value that is passed into `puppeteer.connect()` which is the benchmark-web-vitals command exposes in this PR as `--connect`/`-c`. Nevertheless, upon trying to run this:

```bash
npm run research -- benchmark-web-vitals -u http://example.com -n 1 -p -c 'ws://127.0.0.1:9222/devtools/browser'
```

Nothing happens. And it times out. Sometimes I see a new `about:blank` tab opened on my phone, but otherwise nothing happens. I can see that the call to `puppeteer.connect()` seems to hang.

What I've tried is somewhat similar to what is outlined in [Connecting Puppeteer to Existing Chrome Window w/ reCAPTCHA](https://medium.com/@jaredpotter1/connecting-puppeteer-to-existing-chrome-window-8a10828149e0), but it is specifically for Chrome on Windows not Chrome for Android.