### PR TITLE
Bypass CSP so web vitals script can be reliably injected

### DIFF
--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -210,6 +210,7 @@ async function benchmarkURL( browser, params ) {
 
 	for ( requestNum = 0; requestNum < params.amount; requestNum++ ) {
 		const page = await browser.newPage();
+		await page.setBypassCSP( true ); // Bypass CSP so the web vitals script tag can be injected below.
 		if ( params.cpuThrottleFactor ) {
 			await page.emulateCPUThrottling( params.cpuThrottleFactor );
 		}


### PR DESCRIPTION
Fixes #65.

```
$ npm run research -- benchmark-web-vitals --url 'https://10up.com/' -n 3

> wpp-research@ research /home/westonruter/repos/wpp-research
> ./cli/run.mjs "benchmark-web-vitals" "--url" "https://10up.com/" "-n" "3"

╔═══════════════════╤═══════════════════╗
║ URL               │ https://10up.com/ ║
╟───────────────────┼───────────────────╢
║ Success Rate      │ 100%              ║
╟───────────────────┼───────────────────╢
║ FCP (median)      │ 571.3             ║
╟───────────────────┼───────────────────╢
║ LCP (median)      │ 571.3             ║
╟───────────────────┼───────────────────╢
║ TTFB (median)     │ 478.3             ║
╟───────────────────┼───────────────────╢
║ LCP-TTFB (median) │ 99.1              ║
╚═══════════════════╧═══════════════════╝
```