### PR TITLE
Add query to get scripts blocking in head, counted by plugin

### DIFF
--- a/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
+++ b/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
@@ -57,7 +57,7 @@ function getBlockingHeadScriptSources(data) {
 
     // Blocking script in head only.
     if (!script.in_footer && !script.async && !script.defer) {
-      sources.push( [ source.type, source.slug ].join( ':' ) );
+      sources.push( source.slug );
     }
   }
   return sources;

--- a/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
+++ b/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
@@ -58,7 +58,6 @@ function getBlockingHeadScriptSources(data) {
     // Blocking script in head only.
     if (!script.in_footer && !script.async && !script.defer) {
       sources.push( [ source.type, source.slug ].join( ':' ) );
-      sources.push( [ source.type, source.slug, source.path ].join( ':' ) );
     }
   }
   return sources;

--- a/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
+++ b/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
@@ -99,7 +99,7 @@ WITH
   ),
   plugin_source_counts AS (
     SELECT
-      REGEXP_EXTRACT(source, r'plugin:(.+):') AS plugin,
+      source AS plugin,
       SUM(source_count) AS blocking_scripts
     FROM source_counts
     GROUP BY plugin

--- a/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
+++ b/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
@@ -1,0 +1,111 @@
+# HTTP Archive query to get scripts blocking in head, counted by plugin.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Based on query here: https://github.com/GoogleChromeLabs/wpp-research/pull/63
+CREATE TEMP FUNCTION GET_BLOCKING_HEAD_SOURCES(custom_metrics STRING)
+RETURNS ARRAY<STRING>
+LANGUAGE js
+AS '''
+
+const sourceRegExp = new RegExp( '/wp-content/(?<type>plugin|theme)s/(?<slug>[^/]+)/(?<path>[^\?]+)' );
+
+/**
+ * Get slug of extension prefixed by theme/plugin from URL.
+ *
+ * @param {string} src Script URL.
+ * @return {?{type: "plugin"|"theme", slug: string, path: string}} Source info if matched.
+ */
+function getSource(src) {
+  const matches = src.match( sourceRegExp );
+  if (matches) {
+    return matches.groups;
+  }
+  return null;
+}
+
+/**
+ * Get script sources for scripts in the head which are blocking (not async nor defer).
+ *
+ * @param {object} data
+ * @param {object} data.cms
+ * @param {object} data.cms.wordpress
+ * @param {Array<{src: string, intended_strategy: string, async: boolean, defer: boolean, in_footer: boolean}>} data.cms.wordpress.scripts
+ * @return {Array} Sources.
+ */
+function getBlockingHeadScriptSources(data) {
+  const sources = [];
+  for ( const script of data.cms.wordpress.scripts ) {
+
+    const source = getSource(script.src);
+    if (!source) {
+      continue;
+    }
+
+    // Blocking script in head only.
+    if (!script.in_footer && !script.async && !script.defer) {
+      sources.push( [ source.type, source.slug ].join( ':' ) );
+      sources.push( [ source.type, source.slug, source.path ].join( ':' ) );
+    }
+  }
+  return sources;
+}
+
+const sources = [];
+try {
+  const data = JSON.parse(custom_metrics);
+  sources.push(...getBlockingHeadScriptSources(data));
+} catch (e) {}
+return sources;
+''';
+
+WITH
+  all_sources AS (
+    SELECT
+      GET_BLOCKING_HEAD_SOURCES(custom_metrics) AS sources,
+    FROM
+      `httparchive.all.pages`,
+      UNNEST(technologies) AS technology
+    WHERE
+      date = CAST('2023-07-01' AS DATE)
+      AND technology.technology = 'WordPress'
+      AND is_root_page = TRUE
+  ),
+  source_counts AS (
+    SELECT
+      source,
+      COUNT(source) AS source_count
+    FROM
+      all_sources,
+      UNNEST(sources) AS source
+    GROUP BY
+      source
+    HAVING
+      source_count >= 10000
+    ORDER BY
+      source_count DESC
+  ),
+  plugin_source_counts AS (
+    SELECT
+      REGEXP_EXTRACT(source, r'plugin:(.+):') AS plugin,
+      SUM(source_count) AS blocking_scripts
+    FROM source_counts
+    GROUP BY plugin
+    ORDER BY blocking_scripts DESC
+  )
+SELECT *
+FROM plugin_source_counts
+WHERE plugin IS NOT NULL

--- a/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
+++ b/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
@@ -21,13 +21,13 @@ RETURNS ARRAY<STRING>
 LANGUAGE js
 AS '''
 
-const sourceRegExp = new RegExp( '/wp-content/(?<type>plugin|theme)s/(?<slug>[^/]+)/(?<path>[^\?]+)' );
+const sourceRegExp = new RegExp( '/wp-content/(?<type>plugin)s/(?<slug>[^/]+)/(?<path>[^\?]+)' );
 
 /**
- * Get slug of extension prefixed by theme/plugin from URL.
+ * Get slug of extension prefixed by plugin from URL.
  *
  * @param {string} src Script URL.
- * @return {?{type: "plugin"|"theme", slug: string, path: string}} Source info if matched.
+ * @return {?{type: "plugin", slug: string, path: string}} Source info if matched.
  */
 function getSource(src) {
   const matches = src.match( sourceRegExp );

--- a/sql/README.md
+++ b/sql/README.md
@@ -20,6 +20,7 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ### 2023/08
 
+* [Counts for WordPress blocking head scripts counted by plugin](./2023/08/blocking-in-head-scripts-by-plugin.sql)
 * [Counts for WordPress theme/plugin script placements (whether blocking/async/defer in head/footer)](./2023/08/theme-plugin-script-placements.sql)
 * [Counts of theme/plugin scripts blocking in head](./2023/08/blocking-in-head-scripts-from-themes-and-plugins.sql)
 


### PR DESCRIPTION
## Blocking scripts by plugin
Based on the query from https://github.com/GoogleChromeLabs/wpp-research/pull/63, this query further aggregates the scripts data, counting scripts by plugin.

### Results
|plugin|blocking\_scripts|
|---|---|
|revslider|909952|
|woocommerce|559499|
|elementor|452982|
|LayerSlider|410705|
|pixelyoursite|370128|
|photo\-gallery|367296|
|cookie\-law\-info|361503|
|google\-analytics\-for\-wordpress|360082|
|Ultimate\_VC\_Addons|268471|
|js\_composer|230245|
|sitepress\-multilingual\-cms|192425|
|responsive\-lightbox|166425|
|download\-manager|136044|
|wp\-user\-avatar|134163|
|duracelltomi\-google\-tag\-manager|118564|
|popup\-builder|118371|
|bookly\-responsive\-appointment\-booking\-tool|114151|
|google\-analytics\-dashboard\-for\-wp|111775|
|ele\-custom\-skin|105832|
|modern\-events\-calendar\-lite|102677|
|buddypress|93942|
|wordpress\-popular\-posts|88653|
|addons\-for\-visual\-composer|79441|
|booking|79339|
|wp\-statistics|76445|
|cleantalk\-spam\-protect|73940|
|youtube\-embed\-plus|69393|
|pixelyoursite\-pro|68398|
|search\-filter\-pro|60842|
|enable\-jquery\-migrate\-helper|59285|
|easy\-facebook\-likebox|51071|
|modern\-events\-calendar|50575|
|nextgen\-gallery|48784|
|events\-manager|47979|
|gutenberg|44360|
|mailin|42026|
|ultimate\-member|41309|
|foobox\-image\-lightbox|40178|
|wp\-responsive\-menu|38522|
|wd\-facebook\-feed|38195|
|sticky\-header\-effects\-for\-elementor|37648|
|mailchimp|37222|
|svg\-support|36727|
|borlabs\-cookie|32689|
|sticky\-menu\-or\-anything\-on\-scroll|32244|
|give|30094|
|essential\-grid|30074|
|popups\-for\-divi|28648|
|wp\-video\-lightbox|28313|
|wp\-google\-maps|26442|
|simple\-banner|26341|
|woocommerce\-google\-adwords\-conversion\-tracking\-tag|26176|
|wp\-gdpr\-compliance|26095|
|google\-analytics\-premium|25936|
|buddyboss\-platform|25856|
|wpvr|23680|
|jquery\-updater|23581|
|bold\-page\-builder|23427|
|so\-widgets\-bundle|23311|
|mobile\-menu|22716|
|simple\-google\-recaptcha|22572|
|colibri\-page\-builder\-pro|21803|
|keydesign\-addon|21772|
|feed\-them\-social|21314|
|translatepress\-multilingual|21170|
|gravityforms|20852|
|bt\_cost\_calculator|20512|
|instagram\-widget\-by\-wpzoom|20199|
|webtoffee\-gdpr\-cookie\-consent|20033|
|wp\-user\-frontend|19712|
|aurora\-heatmap|19154|
|thrive\-visual\-editor|18884|
|email\-encoder\-bundle|18837|
|video\-popup|18663|
|testimonial\-rotator|18417|
|meteor\-slides|18124|
|form\-maker|18005|
|simple\-social\-buttons|17823|
|gutenberg\-core|17771|
|advanced\-google\-recaptcha|17503|
|user\-submitted\-posts|17087|
|colibri\-page\-builder|16682|
|dokan\-lite|16388|
|add\-to\-any|16225|
|post\-grid|15931|
|embedpress|15928|
|ct\-ultimate\-gdpr|15458|
|yyi\-rinker|15173|
|featured\-video\-plus|14959|
|google\-analyticator|14916|
|free\-gifts\-for\-woocommerce|14867|
|auto\-terms\-of\-service\-and\-privacy\-policy|14672|
|dethemekit\-for\-elementor|14304|
|responsive\-menu|13992|
|weglot|13757|
|wp\-simple\-firewall|13703|
|wp\-yandex\-metrika|13316|
|chaty|13091|
|handl\-utm\-grabber|12992|
|wpfront\-notification\-bar|12970|
|enjoy\-instagram\-instagram\-responsive\-images\-gallery\-and\-carousel|12933|
|say\-what|12848|
|superfly\-menu|12765|
|stop\-user\-enumeration|12756|
|woocommerce\-menu\-bar\-cart|12733|
|advanced\-custom\-fields\-pro|12509|
|jetpack|12442|
|elementor\-pro|12366|
|all\-in\-one\-wp\-security\-and\-firewall|12293|
|business\-reviews\-bundle|12155|
|jquery\-manager|11934|
|fancybox\-for\-wordpress|11849|
|indeed\-membership\-pro|11772|
|asesor\-cookies\-para\-la\-ley\-en\-espana|11767|
|geodirectory|11722|
|wp\-gpx\-maps|11719|
|ultimate\-addons\-for\-elementor|11705|
|cookie\-notice|11620|
|wp\-embed\-facebook|11604|
|wp\-file\-upload|11541|
|jquery\-vertical\-accordion\-menu|11350|
|flowpaper\-lite\-pdf\-flipbook|11224|
|theia\-post\-slider|11180|
|custom\-registration\-form\-builder\-with\-submission\-manager|11126|
|elementskit|11000|
|wp\-views|10951|
|learnpress|10934|
|simple\-download\-monitor|10848|
|easy\-video\-player|10770|
|wp\-review\-slider\-pro|10637|
|portfolio\-wp|10598|
|memberpress|10598|
|photoswipe\-masonry|10585|
|slider\-wd|10557|
|advanced\-ads|10545|
|widgetkit|10542|
|wt\-smart\-coupons\-for\-woocommerce|10534|
|visitors\-traffic\-real\-time\-statistics|10511|
|top\-bar|10313|
|theplus\_elementor\_addon|10259|
|jquery\-colorbox|10230|
|easy\-social\-icons|10111|
|smart\-logo\-showcase\-lite|10107|