### PR TITLE
Add query to determine frequency of the same image being LCP between desktop & mobile

### DIFF
--- a/sql/2023/10/cross-device-matching-lcp-image.sql
+++ b/sql/2023/10/cross-device-matching-lcp-image.sql
@@ -1,0 +1,75 @@
+# HTTP Archive query to determine frequency of the same image being the LCP element between desktop and mobile on WordPress pages.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: ...
+
+# h/t https://github.com/GoogleChromeLabs/wpp-research/blob/0b6c2ca8ddc2c68d4eddcb3d4e069c5e75a2ca16/sql/2023/03/top-lazy-lcp-class-names.sql#L18-L26
+CREATE TEMP FUNCTION getAttr(attributes STRING, attribute STRING) RETURNS STRING LANGUAGE js AS '''
+  try {
+    const data = JSON.parse(attributes);
+    const attr = data.find(attr => attr["name"] === attribute)
+    return attr.value
+  } catch (e) {
+    return null;
+  }
+''';
+
+# h/t https://colab.research.google.com/drive/1lbTFTy1IoifpqkynKuualVjrLVSj1i0r#scrollTo=wszyW57bElAb&line=47&uniqifier=1
+CREATE TEMPORARY FUNCTION IS_CMS(technologies ARRAY<STRUCT<technology STRING, categories ARRAY<STRING>, info ARRAY<STRING>>>, cms STRING, version STRING) RETURNS BOOL AS (
+  EXISTS(
+    SELECT * FROM UNNEST(technologies) AS technology, UNNEST(technology.info) AS info
+    WHERE technology.technology = cms
+      AND (
+          version = ""
+        OR ENDS_WITH(version, ".x") AND (STARTS_WITH(info, RTRIM(version, "x")) OR info = RTRIM(version, ".x"))
+        OR info = version
+      )
+  )
+);
+
+WITH
+  all_device_wordpress_lcp AS (
+    SELECT
+      page,
+      IF(client = "mobile", "phone", "desktop") AS device,
+      IF(getAttr(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes'), 'fetchpriority') = 'high', true, false) AS has_fetchpriority,
+      JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.nodeName') AS lcp_element,
+    FROM
+      `httparchive.all.pages`
+    WHERE
+      date = '2023-08-01' AND
+      is_root_page AND
+      IS_CMS(technologies, "WordPress", "6.3.x")
+  ),
+
+  matched_device_wordpress_lcp AS (
+    SELECT
+      IF(desktop_wordpress_lcp.has_fetchpriority = mobile_wordpress_lcp.has_fetchpriority, true, false) AS lcp_images_have_same_fetchpriority
+    FROM
+      ( SELECT * FROM all_device_wordpress_lcp WHERE device = 'desktop' AND lcp_element = 'IMG' ) AS desktop_wordpress_lcp
+        INNER JOIN
+      ( SELECT * FROM all_device_wordpress_lcp WHERE device = 'phone' AND lcp_element = 'IMG' ) AS mobile_wordpress_lcp
+    ON
+      desktop_wordpress_lcp.page = mobile_wordpress_lcp.page
+  )
+
+SELECT
+  lcp_images_have_same_fetchpriority,
+  COUNT( lcp_images_have_same_fetchpriority ) as same_count
+FROM
+  matched_device_wordpress_lcp
+GROUP BY
+  lcp_images_have_same_fetchpriority

--- a/sql/2023/10/cross-device-matching-lcp-image.sql
+++ b/sql/2023/10/cross-device-matching-lcp-image.sql
@@ -40,8 +40,7 @@ CREATE TEMPORARY FUNCTION IS_CMS(technologies ARRAY<STRUCT<technology STRING, ca
   )
 );
 
-WITH
-  all_device_wordpress_lcp AS (
+WITH all_device_wordpress_lcp AS (
     SELECT
       page,
       IF(client = "mobile", "phone", "desktop") AS device,

--- a/sql/2023/10/cross-device-matching-lcp-image.sql
+++ b/sql/2023/10/cross-device-matching-lcp-image.sql
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# See query results here: ...
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/73
 
 # h/t https://github.com/GoogleChromeLabs/wpp-research/blob/0b6c2ca8ddc2c68d4eddcb3d4e069c5e75a2ca16/sql/2023/03/top-lazy-lcp-class-names.sql#L18-L26
 CREATE TEMP FUNCTION getAttr(attributes STRING, attribute STRING) RETURNS STRING LANGUAGE js AS '''
@@ -57,19 +57,21 @@ WITH
 
   matched_device_wordpress_lcp AS (
     SELECT
-      IF(desktop_wordpress_lcp.has_fetchpriority = mobile_wordpress_lcp.has_fetchpriority, true, false) AS lcp_images_have_same_fetchpriority
+      IF(desktop_wordpress_lcp.has_fetchpriority = mobile_wordpress_lcp.has_fetchpriority, true, false) AS lcp_images_both_have_fetchpriority
     FROM
       ( SELECT * FROM all_device_wordpress_lcp WHERE device = 'desktop' AND lcp_element = 'IMG' ) AS desktop_wordpress_lcp
         INNER JOIN
       ( SELECT * FROM all_device_wordpress_lcp WHERE device = 'phone' AND lcp_element = 'IMG' ) AS mobile_wordpress_lcp
     ON
       desktop_wordpress_lcp.page = mobile_wordpress_lcp.page
+    WHERE
+      desktop_wordpress_lcp.has_fetchpriority OR mobile_wordpress_lcp.has_fetchpriority
   )
 
 SELECT
-  lcp_images_have_same_fetchpriority,
-  COUNT( lcp_images_have_same_fetchpriority ) as same_count
+  lcp_images_both_have_fetchpriority,
+  COUNT( lcp_images_both_have_fetchpriority ) as count
 FROM
   matched_device_wordpress_lcp
 GROUP BY
-  lcp_images_have_same_fetchpriority
+  lcp_images_both_have_fetchpriority

--- a/sql/2023/10/cross-device-matching-lcp-image.sql
+++ b/sql/2023/10/cross-device-matching-lcp-image.sql
@@ -60,7 +60,7 @@ WITH
       IF(desktop_wordpress_lcp.has_fetchpriority = mobile_wordpress_lcp.has_fetchpriority, true, false) AS lcp_images_both_have_fetchpriority
     FROM
       ( SELECT * FROM all_device_wordpress_lcp WHERE device = 'desktop' AND lcp_element = 'IMG' ) AS desktop_wordpress_lcp
-        INNER JOIN
+    INNER JOIN
       ( SELECT * FROM all_device_wordpress_lcp WHERE device = 'phone' AND lcp_element = 'IMG' ) AS mobile_wordpress_lcp
     ON
       desktop_wordpress_lcp.page = mobile_wordpress_lcp.page

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,10 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/10
+
+* [Counts for whether pages have `fetchpriority=high` on both desktop and mobile LCP images](./2023/10/cross-device-matching-lcp-image.sql)
+
 ### 2023/08
 
 * [Counts for WordPress theme/plugin script placements (whether blocking/async/defer in head/footer)](./2023/08/theme-plugin-script-placements.sql)


### PR DESCRIPTION
The current PHP heuristics adds `fetchpriority=high` to the same image for both desktop and mobile clients. Nevertheless, some sites serve different assets for desktop and mobile via CSS media queries. In such cases, when the LCP image on desktop is given `fetchpriority=high`, it can be that for mobile that the LCP image lacks `fetchpriority=high` and also gets `loading=lazy`. This PR seeks to determine how common a scenario this is.

At present, it is only considering cases in which `fetchpriority=high` was added correctly to the LCP image for _either_ the desktop or the mobile. If so, then it counts how often or not both desktop and mobile have `fetchpriority=high` on the LCP image. It is also only considering mobile and desktop pages which _both_ have an image as the LCP element. Lastly, it only considers WordPress 6.3.x since this is the version in which `fetchpriority` was introduced.

lcp_images_both_have_fetchpriority | count
--- | ---:
false | 25,860
true | 44,601
Total: | 70,461

<small>(Query elapsed time: 11 min 38 sec)</small>

Of the matching pages, ~63% (25,860/70,461) have the same image as LCP for desktop and mobile. (Or technically that both of these images have `fetchpriority=high`, which WordPress only adds to one image.) So there is ~37% headroom here to improve LCP detection.

Note that this does not account for the case when `fetchpriority=high` is missing on both the LCP image for desktop and mobile. To account for this, we would not be able to rely on `lcp_elem_stats` or `raw_lcp_element` since they lack sufficient information:

<details><summary>JSON</summary>

```json
{
  "_performance": {
    "lcp_elem_stats": {
      "startTime": 3429.900000002235,
      "nodeName": "IMG",
      "url": "https:\/\/example.com\/foo.jpg",
      "size": 53130,
      "loadTime": 3422.4,
      "renderTime": 3429.9,
      "attributes": [
        {
          "name": "width",
          "value": "768"
        },
        {
          "name": "height",
          "value": "480"
        },
        {
          "name": "src",
          "value": "https:\/\/example.com\/foo.jpg"
        },
        {
          "name": "class",
          "value": "wp-post-image"
        },
        {
          "name": "alt",
          "value": "some alt text"
        },
        {
          "name": "decoding",
          "value": "async"
        },
        {
          "name": "loading",
          "value": "lazy"
        },
        {
          "name": "srcset",
          "value": "https:\/\/example.com\/foo.jpg 768w, https:\/\/example.com\/foo-320x200.jpg 320w"
        },
        {
          "name": "sizes",
          "value": "(max-width: 768px) 100vw, 768px"
        },
        {
          "name": "title",
          "value": "some title"
        }
      ],
      "boundingClientRect": {
        "x": 15,
        "y": 1354.359375,
        "width": 330,
        "height": 206.234375,
        "top": 1354.359375,
        "right": 345,
        "bottom": 1560.59375,
        "left": 15
      },
      "naturalWidth": 359,
      "naturalHeight": 224,
      "styles": {
        "background-image": "",
        "pointer-events": "",
        "position": "",
        "width": "",
        "height": ""
      },
      "cover90viewport": false
    },
    "raw_lcp_element": {
      "nodeName": "IMG",
      "attributes": [
        {
          "name": "width",
          "value": "768"
        },
        {
          "name": "height",
          "value": "480"
        },
        {
          "name": "src",
          "value": "https:\/\/example.com\/foo.jpg"
        },
        {
          "name": "class",
          "value": "wp-post-image"
        },
        {
          "name": "alt",
          "value": "some alt text"
        },
        {
          "name": "decoding",
          "value": "async"
        },
        {
          "name": "loading",
          "value": "lazy"
        },
        {
          "name": "srcset",
          "value": "https:\/\/example.com\/foo.jpg 768w, https:\/\/example.com\/foo-320x200.jpg 320w"
        },
        {
          "name": "sizes",
          "value": "(max-width: 768px) 100vw, 768px"
        },
        {
          "name": "title",
          "value": "some title"
        }
      ]
    }
  }
}
```

</details> 

In order to expand the set of URLs beyond ~70K, we would need to query for the LCP element on desktop and mobile, and then compare the image attributes or the CSS selectors as is exposed by the Lighthouse audit. However, this is complicated by the fact that the desktop and mobile crawls by HTTP Archive may reflect different states of the page, such as when a new article is published and appears at the top of the homepage between desktop and mobile crawls. When this happens, the `src` of the LCP elements will no longer match so they cannot be compared, and the selectors could involve some attachment ID or post ID, so they may not be reliable to compare either.