### PR TITLE
Add query to count `content-type` headers used for WordPress pages

### DIFF
--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# See query results here: ...
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/74
 WITH
 
   pages AS (

--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -39,6 +39,7 @@ WITH
       UNNEST(response_headers) as resp_headers
     WHERE
       date = "2023-08-01" AND
+      is_root_page AND
       lower(resp_headers.name) = 'content-type' AND
       is_main_document AND
       root_page = url

--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -16,33 +16,33 @@
 
 # See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/74
 WITH pages AS (
-    SELECT
-      client,
-      page AS url
-    FROM
-      `httparchive.all.pages`,
-      UNNEST(technologies) AS t
-    WHERE
-      date = '2023-08-01' AND
-      is_root_page AND
-      t.technology = 'WordPress'
-  ),
+  SELECT
+    client,
+    page AS url
+  FROM
+    `httparchive.all.pages`,
+    UNNEST(technologies) AS t
+  WHERE
+    date = '2023-08-01' AND
+    is_root_page AND
+    t.technology = 'WordPress'
+),
 
-  # h/t https://discuss.httparchive.org/t/help-finding-list-of-home-pages-with-specific-http-response-header/2567/2
-  requests AS (
-    SELECT
-      client,
-      url,
-      REGEXP_REPLACE( resp_headers.value, ' *;.*$', '' ) AS content_type
-    FROM
-      `httparchive.all.requests`,
-      UNNEST(response_headers) as resp_headers
-    WHERE
-      date = "2023-08-01" AND
-      is_root_page AND
-      lower(resp_headers.name) = 'content-type' AND
-      is_main_document
-  )
+# h/t https://discuss.httparchive.org/t/help-finding-list-of-home-pages-with-specific-http-response-header/2567/2
+requests AS (
+  SELECT
+    client,
+    url,
+    REGEXP_REPLACE( resp_headers.value, ' *;.*$', '' ) AS content_type
+  FROM
+    `httparchive.all.requests`,
+    UNNEST(response_headers) as resp_headers
+  WHERE
+    date = "2023-08-01" AND
+    is_root_page AND
+    lower(resp_headers.name) = 'content-type' AND
+    is_main_document
+)
 
 SELECT
   client,

--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -17,6 +17,7 @@
 # See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/74
 WITH pages AS (
     SELECT
+      client,
       page AS url
     FROM
       `httparchive.all.pages`,
@@ -24,13 +25,13 @@ WITH pages AS (
     WHERE
       date = '2023-08-01' AND
       is_root_page AND
-      client = 'mobile' AND
       t.technology = 'WordPress'
   ),
 
   # h/t https://discuss.httparchive.org/t/help-finding-list-of-home-pages-with-specific-http-response-header/2567/2
   requests AS (
     SELECT
+      client,
       url,
       REGEXP_REPLACE( resp_headers.value, ' *;.*$', '' ) AS content_type
     FROM
@@ -39,21 +40,23 @@ WITH pages AS (
     WHERE
       date = "2023-08-01" AND
       is_root_page AND
-      client = 'mobile' AND
       lower(resp_headers.name) = 'content-type' AND
       is_main_document
   )
 
 SELECT
+  client,
   content_type,
-  COUNT(content_type) AS count
+  COUNT(url) AS count
 FROM
   requests
 INNER JOIN
   pages
 USING
-  (url)
+  (client, url)
 GROUP BY
+  client,
   content_type
 ORDER BY
+  client,
   count DESC

--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -15,9 +15,7 @@
 # limitations under the License.
 
 # See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/74
-WITH
-
-  pages AS (
+WITH pages AS (
     SELECT
       page AS url
     FROM

--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -19,7 +19,7 @@ WITH
 
   pages AS (
     SELECT
-      page
+      page AS url
     FROM
       `httparchive.all.pages`,
       UNNEST(technologies) AS t
@@ -49,10 +49,10 @@ SELECT
   COUNT(content_type) AS count
 FROM
   requests
-JOIN
+INNER JOIN
   pages
-ON
-  pages.page = requests.url
+USING
+  (url)
 GROUP BY
   content_type
 ORDER BY

--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -26,6 +26,7 @@ WITH
     WHERE
       date = '2023-08-01' AND
       is_root_page AND
+      client = 'mobile' AND
       t.technology = 'WordPress'
   ),
 
@@ -40,6 +41,7 @@ WITH
     WHERE
       date = "2023-08-01" AND
       is_root_page AND
+      client = 'mobile' AND
       lower(resp_headers.name) = 'content-type' AND
       is_main_document AND
       root_page = url

--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -41,8 +41,7 @@ WITH pages AS (
       is_root_page AND
       client = 'mobile' AND
       lower(resp_headers.name) = 'content-type' AND
-      is_main_document AND
-      root_page = url
+      is_main_document
   )
 
 SELECT

--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -1,0 +1,59 @@
+# HTTP Archive query to get counts of content-types used for WordPress pages.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: ...
+WITH
+
+  pages AS (
+    SELECT
+      page
+    FROM
+      `httparchive.all.pages`,
+      UNNEST(technologies) AS t
+    WHERE
+      date = '2023-08-01' AND
+      is_root_page AND
+      t.technology = 'WordPress'
+  ),
+
+  # h/t https://discuss.httparchive.org/t/help-finding-list-of-home-pages-with-specific-http-response-header/2567/2
+  requests AS (
+    SELECT
+      url,
+      REGEXP_REPLACE( resp_headers.value, ' *;.*$', '' ) AS content_type
+    FROM
+      `httparchive.all.requests`,
+      UNNEST(response_headers) as resp_headers
+    WHERE
+      date = "2023-08-01" AND
+      lower(resp_headers.name) = 'content-type' AND
+      is_main_document AND
+      root_page = url
+  )
+
+SELECT
+  content_type,
+  COUNT(content_type) AS count
+FROM
+  requests
+JOIN
+  pages
+ON
+  pages.page = requests.url
+GROUP BY
+  content_type
+ORDER BY
+  count DESC

--- a/sql/README.md
+++ b/sql/README.md
@@ -18,6 +18,10 @@ Once you are ready to add a new query to the repository, open a pull request fol
 
 ## Query index
 
+### 2023/10
+
+* [Counts for Content-Types used for WordPress pages](./2023/10/page-content-types.sql)
+
 ### 2023/08
 
 * [Counts for WordPress theme/plugin script placements (whether blocking/async/defer in head/footer)](./2023/08/theme-plugin-script-placements.sql)


### PR DESCRIPTION
In [discussing](https://wordpress.slack.com/archives/C05NFB818PQ/p1695770376425949) with @dmsnell in the #core-html-api Slack channel about [whether XHTML support should be removed from core](https://wordpress.slack.com/archives/C05NFB818PQ/p1695776267247279), I wanted to do a query to see how many WordPress pages are actually served with the `Content-Type` of `application/xhtml+xml`. Even when the response body contains valid XML/XHTML markup, browsers will still use the HTML parser if the `Content-Type` is `text/html`. So we can determine whether attempting to maintain valid XHTML syntax is important for WordPress by checking how often pages are returned as `application/xhtml+xml`. Presuming my query is correct, in short, the answer is very few: specifically **four** and they are all limited to mobile. In fact, there are more pages returned as RSS or plain text than XHTML.

client | content_type | count
-- | -- | --:
desktop | text/html | 4082654
desktop | application/rss+xml | 32
desktop | text/plain | 11
desktop | application/x-perl | 2
desktop | text | 2
desktop |   | 2
desktop | x-httpd-php | 2
desktop | texthtml | 2
desktop | twentyseventeen | 1
desktop | html_type | 1
desktop | charset=utf-8 | 1
desktop | text/xml | 1
desktop | text/css | 1
desktop | another text/html | 1
desktop | 1 | 1
desktop | application/atom+xml | 1
desktop | application/json | 1
mobile | text/html | 5459935
mobile | application/rss+xml | 61
mobile | text/xml | 7
mobile | text/plain | 7
**mobile** | **application/xhtml+xml** | **4**
mobile | texthtml | 3
mobile |   | 3
mobile | text | 2
mobile | text/HTML | 2
mobile | charset=utf-8 | 2
mobile | x-httpd-php | 2
mobile | html_type | 1
mobile | application/x-perl | 1
mobile | 1 | 1
mobile | Array | 1
mobile | text/css | 1
mobile | twentyseventeen | 1
mobile | another text/html | 1
mobile | utf-8 | 1
mobile | text/htmltext/html | 1
mobile | application/atom+xml | 1
mobile | application/json | 1

(Query elapsed time: 53 sec)

I checked the four URLs that were being returned as `application/xhtml+xml` when crawled, and <del>they are all</del> <ins>one is</ins> returning `text/html` now. <ins>The other three are returning `application/xhtml+xml` _only_ when emulating a mobile device.</ins>

For reference, these are the URLs which were serving valid XHTML at crawl time:

1. http://www.kenkomura.jp/ (XHTML only for mobile)
2. http://www.nukumori-fukumitsu.com/ (XHTML only for mobile)
3. http://kittokito-ichiba.co.jp/ (XHTML only for mobile)
4. https://yakaze.jp/ (not XHTML for either desktop or mobile now)

Interestingly the sites are all Japanese.

So I think it is safe to say that WordPress can safely abandon any attempt to serve valid XML pages.
