### PR TITLE
Enhance `benchmark-web-vitals` with specific metric filtering and Server-Timing support

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -157,6 +157,7 @@ Loads the provided URLs in a headless browser several times to measure median We
 * `--url` (`-u`): A URL to benchmark.
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
+* `--metrics` (`-m`): Which metrics to include; by default these are "FCP", "LCP", "TTFB" and "LCP-TTFB".
 * `--output` (`-o`): The output format: Either "table" or "csv".
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 * `--throttle-cpu` (`-t`): Enable CPU throttling to emulate slow CPUs.
@@ -172,6 +173,11 @@ benchmark-web-vitals --url https://example.com/ -n 10
 Same as above, but results are formatted as CSV:
 ```bash
 benchmark-web-vitals --url https://example.com/ -n 10 --output csv
+```
+
+To include a different (sub)set of metrics (e.g. "TTFB" and "LCP-TTFB"):
+```bash
+benchmark-web-vitals --url https://example.com/ -n 10 --metrics TTFB "LCP-TTFB"
 ```
 
 To include more granular percentiles rather than only the median for each metric:

--- a/cli/README.md
+++ b/cli/README.md
@@ -180,6 +180,11 @@ To include a different (sub)set of metrics (e.g. "TTFB" and "LCP-TTFB"):
 benchmark-web-vitals --url https://example.com/ -n 10 --metrics TTFB "LCP-TTFB"
 ```
 
+To include a custom Server-Timing metric like `wp-total` (only if configured on the server):
+```bash
+benchmark-web-vitals --url https://example.com/ -n 10 --metrics ST:wp-total
+```
+
 To include more granular percentiles rather than only the median for each metric:
 ```bash
 benchmark-web-vitals --url https://example.com/ -n 10 --show-percentiles

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -97,6 +97,16 @@ export const options = [
  */
 
 /**
+ * @typedef {Object} MetricsDefinitionEntry
+ * @property {string}    type     Either 'webVitals', 'serverTiming', or 'aggregate'.
+ * @property {?string}   listen   Which event to listen to (only relevant for type 'webVitals').
+ * @property {?string}   global   Which JS global to find the metric in (only relevant for type 'webVitals').
+ * @property {?string[]} add      Which other metrics to add (only relevant for type 'aggregate').
+ * @property {?string[]} subtract Which other metrics to subtract (only relevant for type 'aggregate').
+ * @property {?string}   name     Name of the Server-Timing metric (only relevant for type 'serverTiming').
+ */
+
+/**
  * @param {Object}                opt
  * @param {?string}               opt.url
  * @param {string|number}         opt.number
@@ -168,7 +178,7 @@ function getParamsFromOptions( opt ) {
 
 /**
  * @param {string[]} metrics
- * @return {Object} Metrics definition, keyed my metric identifier.
+ * @return {Object<string, MetricsDefinitionEntry>} Metrics definition, keyed by metric identifier.
  */
 function getMetricsDefinition( metrics ) {
 	/*
@@ -201,9 +211,12 @@ function getMetricsDefinition( metrics ) {
 		},
 	};
 
-	/*
+	/**
 	 * Server-Timing metrics can have any name, so for those a generic definition creator is used.
 	 * These metrics must be prefixed with "ST:", see below.
+	 *
+	 * @param {string} metric
+	 * @return {MetricsDefinitionEntry} Server-Timing metrics definition entry.
 	 */
 	const getServerTimingDefinition = ( metric ) => {
 		return {
@@ -290,10 +303,10 @@ export async function handler( opt ) {
 }
 
 /**
- * @param {string}  url
- * @param {Browser} browser
- * @param {Object}  metricsDefinition
- * @param {Params}  params
+ * @param {string}                 url
+ * @param {Browser}                browser
+ * @param {MetricsDefinitionEntry} metricsDefinition
+ * @param {Params}                 params
  * @return {Promise<{completeRequests: number, metrics: {}}>} Results
  */
 async function benchmarkURL( url, browser, metricsDefinition, params ) {

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -222,10 +222,15 @@ function getMetricsDefinition( metrics ) {
 		return {
 			type: 'serverTiming',
 			name: metric,
+			listen: null,
+			global: null,
+			add: null,
+			subtract: null,
 		};
 	};
 
 	// Set up object with the requested metrics, and store aggregate metrics in a list.
+	/** @type {Object<string, MetricsDefinitionEntry>} */
 	const metricsDefinition = {};
 	const aggregates = [];
 	for ( const metric of metrics ) {
@@ -400,10 +405,8 @@ async function benchmarkURL( url, browser, metricsDefinition, params ) {
 							offset: { x: -500, y: -500 },
 						} );
 						// Get the metric value from the global.
-						/** @type {number} */
-						const metric = await page.evaluate(
-							( global ) =>
-								/** @type {number} */ window[ global ],
+						const metric = /** @type {number} */ await page.evaluate(
+							( global ) => window[ global ],
 							value.global
 						);
 						value.results.push( metric );

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -415,14 +415,21 @@ async function benchmarkURL( url, browser, metricsDefinition, params ) {
 		}
 
 		if ( groupedMetrics.serverTiming ) {
-			const serverTimingMetrics = await page.evaluate( () =>
-				performance
-					.getEntries()[ 0 ]
-					.serverTiming.reduce( ( acc, value ) => {
-						acc[ value.name ] = value.duration;
-						return acc;
-					}, {} )
-			);
+			const serverTimingMetrics = await page.evaluate( () => {
+				const entry = performance.getEntries().find(
+					( entry ) => entry instanceof PerformanceNavigationTiming
+				);
+				if ( entry instanceof PerformanceNavigationTiming ) {
+					return entry.serverTiming.reduce(
+						( acc, value ) => {
+							acc[ value.name ] = value.duration;
+							return acc;
+						}, {}
+					);
+				} else {
+					return {};
+				}
+			} );
 			Object.values( groupedMetrics.serverTiming ).forEach( ( value ) => {
 				if ( serverTimingMetrics[ value.name ] ) {
 					value.results.push( serverTimingMetrics[ value.name ] );

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -405,10 +405,11 @@ async function benchmarkURL( url, browser, metricsDefinition, params ) {
 							offset: { x: -500, y: -500 },
 						} );
 						// Get the metric value from the global.
-						const metric = /** @type {number} */ await page.evaluate(
-							( global ) => window[ global ],
-							value.global
-						);
+						const metric =
+							/** @type {number} */ await page.evaluate(
+								( global ) => window[ global ],
+								value.global
+							);
 						value.results.push( metric );
 					}
 				)

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -183,19 +183,16 @@ function getMetricsDefinition( metrics ) {
 			type: 'webVitals',
 			listen: 'onFCP',
 			global: 'webVitalsFCP',
-			results: [],
 		},
 		LCP: {
 			type: 'webVitals',
 			listen: 'onLCP',
 			global: 'webVitalsLCP',
-			results: [],
 		},
 		TTFB: {
 			type: 'webVitals',
 			listen: 'onTTFB',
 			global: 'webVitalsTTFB',
-			results: [],
 		},
 		'LCP-TTFB': {
 			type: 'aggregate',
@@ -212,7 +209,6 @@ function getMetricsDefinition( metrics ) {
 		return {
 			type: 'serverTiming',
 			name: metric,
-			results: [],
 		};
 	};
 
@@ -310,6 +306,7 @@ async function benchmarkURL( url, browser, metricsDefinition, params ) {
 		}
 		groupedMetrics[ metricType ][ metric ] = {
 			...metricsDefinition[ metric ],
+			results: [],
 		};
 	} );
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -416,16 +416,17 @@ async function benchmarkURL( url, browser, metricsDefinition, params ) {
 
 		if ( groupedMetrics.serverTiming ) {
 			const serverTimingMetrics = await page.evaluate( () => {
-				const entry = performance.getEntries().find(
-					( entry ) => entry instanceof PerformanceNavigationTiming
-				);
-				if ( entry instanceof PerformanceNavigationTiming ) {
-					return entry.serverTiming.reduce(
-						( acc, value ) => {
-							acc[ value.name ] = value.duration;
-							return acc;
-						}, {}
+				const entry = performance
+					.getEntries()
+					.find(
+						( entry ) =>
+							entry instanceof PerformanceNavigationTiming
 					);
+				if ( entry instanceof PerformanceNavigationTiming ) {
+					return entry.serverTiming.reduce( ( acc, value ) => {
+						acc[ value.name ] = value.duration;
+						return acc;
+					}, {} );
 				} else {
 					return {};
 				}

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -416,20 +416,17 @@ async function benchmarkURL( url, browser, metricsDefinition, params ) {
 
 		if ( groupedMetrics.serverTiming ) {
 			const serverTimingMetrics = await page.evaluate( () => {
-				const entry = performance
-					.getEntries()
-					.find(
-						( entry ) =>
-							entry instanceof PerformanceNavigationTiming
-					);
+				const entry = performance.getEntries().find(
+					( ent ) => ent instanceof PerformanceNavigationTiming // eslint-disable-line no-undef
+				);
+				// eslint-disable-next-line no-undef
 				if ( entry instanceof PerformanceNavigationTiming ) {
 					return entry.serverTiming.reduce( ( acc, value ) => {
 						acc[ value.name ] = value.duration;
 						return acc;
 					}, {} );
-				} else {
-					return {};
 				}
+				return {};
 			} );
 			Object.values( groupedMetrics.serverTiming ).forEach( ( value ) => {
 				if ( serverTimingMetrics[ value.name ] ) {

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -308,10 +308,10 @@ export async function handler( opt ) {
 }
 
 /**
- * @param {string}                 url
- * @param {Browser}                browser
- * @param {MetricsDefinitionEntry} metricsDefinition
- * @param {Params}                 params
+ * @param {string}                                 url
+ * @param {Browser}                                browser
+ * @param {Object<string, MetricsDefinitionEntry>} metricsDefinition
+ * @param {Params}                                 params
  * @return {Promise<{completeRequests: number, metrics: {}}>} Results
  */
 async function benchmarkURL( url, browser, metricsDefinition, params ) {

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -511,9 +511,9 @@ async function benchmarkURL( url, browser, metricsDefinition, params ) {
 	 * be part of the final list.
 	 */
 	const metrics = {};
-	params.metrics.forEach( ( metric ) => {
+	for ( const metric of params.metrics ) {
 		metrics[ metric ] = metricResults[ metric ];
-	} );
+	}
 
 	return { completeRequests, metrics };
 }


### PR DESCRIPTION
This PR adds two features to the `benchmark-web-vitals` command:
1. A `--metrics` (`-m`) parameter that allows including specific metrics. You could use it to e.g. only get "TTFB" returned. The default metrics if the parameter is not provided remain the same ones as they have been so far ("FCP", "LCP", "TTFB", "LCP-TTFB").
2. Support for including specific Server-Timing metrics in the results, via the new parameter. You can pass any metric name prefixed with "ST:" (e.g. "ST:wp-total"), and it will be included in the data. Obviously it'll only have values if the server response includes the relevant header.

While 1. is certainly a nice little convenience enhancement, 2. may seem a bit questionable at first glance since we already have the `benchmark-server-timing` command, which is much more efficient for that. And for use-cases where only Server-Timing values are needed, or where the reduced variance of using `curl` for Server-Timing metrics is of particular importance, `benchmark-server-timing` continues to be the better choice. However, optionally supporting Server-Timing metrics to be included in `benchmark-web-vitals` allows to get these metrics from a browser request together with e.g. certain Web Vitals. An example use-case (and the reason I worked on this in the first place) is to compare `wp-total` as returned by the server with actual TTFB.

For examples using these two new features, see the updated docs in the readme file.