### PR TITLE
Log progress when benchmarking multiple URLs

### DIFF
--- a/cli/commands/analyze-loading-optimization.mjs
+++ b/cli/commands/analyze-loading-optimization.mjs
@@ -31,7 +31,7 @@ import round from 'lodash-es/round.js';
  */
 import {
 	isValidTableFormat,
-	log,
+	output,
 	table,
 	OUTPUT_FORMAT_TABLE,
 } from '../lib/cli/logger.mjs';
@@ -171,7 +171,7 @@ function formatValue( value ) {
  */
 function outputResults( params, urlReport ) {
 	if ( params.output === 'json' ) {
-		log( JSON.stringify( urlReport, null, 4 ) );
+		output( JSON.stringify( urlReport, null, 4 ) );
 		return;
 	}
 
@@ -195,8 +195,8 @@ function outputResults( params, urlReport ) {
 			}
 		}
 
-		log( headings.join( ',' ) );
-		log( values.join( ',' ) );
+		output( headings.join( ',' ) );
+		output( values.join( ',' ) );
 		return;
 	}
 
@@ -215,7 +215,7 @@ function outputResults( params, urlReport ) {
 		tableData.push( tableRow );
 	}
 
-	log( table( headings, tableData, params.output ) );
+	output( table( headings, tableData, params.output ) );
 }
 
 /**

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -86,10 +86,10 @@ export async function handler( opt ) {
 	const results = [];
 
 	// Log progress only under certain conditions (multiple URLs to benchmark).
-	const logProgress = shouldLogURLProgress( opt );
+	const logURLProgress = shouldLogURLProgress( opt );
 
 	for await ( const url of getURLs( opt ) ) {
-		if ( logProgress ) {
+		if ( logURLProgress ) {
 			logPartial( `Benchmarking URL ${ url }...` );
 		}
 
@@ -101,7 +101,7 @@ export async function handler( opt ) {
 					amount,
 				} );
 			results.push( [ url, completeRequests, responseTimes, metrics ] );
-			if ( logProgress ) {
+			if ( logURLProgress ) {
 				log( formats.success( 'Success.' ) );
 			}
 		} catch ( err ) {

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -25,7 +25,7 @@ import round from 'lodash-es/round.js';
 /**
  * Internal dependencies
  */
-import { getURLs } from '../lib/cli/args.mjs';
+import { getURLs, logURLProgress } from '../lib/cli/args.mjs';
 import {
 	log,
 	formats,
@@ -83,16 +83,28 @@ export async function handler( opt ) {
 	const { concurrency: connections, number: amount } = opt;
 	const results = [];
 
-	for await ( const url of getURLs( opt ) ) {
-		const { completeRequests, responseTimes, metrics } = await benchmarkURL(
-			{
-				url,
-				connections,
-				amount,
-			}
-		);
+	// Log progress only under certain conditions (multiple URLs to benchmark).
+	const logProgress = logURLProgress( opt );
 
-		results.push( [ url, completeRequests, responseTimes, metrics ] );
+	for await ( const url of getURLs( opt ) ) {
+		if ( logProgress ) {
+			log( `Benchmarking URL ${ url }...` );
+		}
+
+		try {
+			const { completeRequests, responseTimes, metrics } =
+				await benchmarkURL( {
+					url,
+					connections,
+					amount,
+				} );
+			results.push( [ url, completeRequests, responseTimes, metrics ] );
+			if ( logProgress ) {
+				log( formats.success( 'Success.' ) );
+			}
+		} catch ( err ) {
+			log( formats.error( `Error: ${ err.message }.` ) );
+		}
 	}
 
 	if ( results.length === 0 ) {

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -28,6 +28,8 @@ import round from 'lodash-es/round.js';
 import { getURLs, shouldLogURLProgress } from '../lib/cli/args.mjs';
 import {
 	log,
+	logPartial,
+	output,
 	formats,
 	table,
 	isValidTableFormat,
@@ -88,7 +90,7 @@ export async function handler( opt ) {
 
 	for await ( const url of getURLs( opt ) ) {
 		if ( logProgress ) {
-			log( `Benchmarking URL ${ url }...` );
+			logPartial( `Benchmarking URL ${ url }...` );
 		}
 
 		try {
@@ -264,5 +266,5 @@ function outputResults( opt, results ) {
 		tableData.push( tableRow );
 	}
 
-	log( table( headings, tableData, opt.output, true ) );
+	output( table( headings, tableData, opt.output, true ) );
 }

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -25,7 +25,7 @@ import round from 'lodash-es/round.js';
 /**
  * Internal dependencies
  */
-import { getURLs, logURLProgress } from '../lib/cli/args.mjs';
+import { getURLs, shouldLogURLProgress } from '../lib/cli/args.mjs';
 import {
 	log,
 	formats,
@@ -84,7 +84,7 @@ export async function handler( opt ) {
 	const results = [];
 
 	// Log progress only under certain conditions (multiple URLs to benchmark).
-	const logProgress = logURLProgress( opt );
+	const logProgress = shouldLogURLProgress( opt );
 
 	for await ( const url of getURLs( opt ) ) {
 		if ( logProgress ) {

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -33,6 +33,8 @@ import round from 'lodash-es/round.js';
 import { getURLs, shouldLogURLProgress } from '../lib/cli/args.mjs';
 import {
 	log,
+	logPartial,
+	output,
 	formats,
 	table,
 	isValidTableFormat,
@@ -292,7 +294,7 @@ export async function handler( opt ) {
 
 	for await ( const url of getURLs( opt ) ) {
 		if ( logProgress ) {
-			log( `Benchmarking URL ${ url }...` );
+			logPartial( `Benchmarking URL ${ url }...` );
 		}
 
 		// Catch Puppeteer errors to prevent the process from getting stuck.
@@ -595,5 +597,5 @@ function outputResults( opt, results ) {
 		tableData.push( tableRow );
 	}
 
-	log( table( headings, tableData, opt.output, true ) );
+	output( table( headings, tableData, opt.output, true ) );
 }

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -30,7 +30,7 @@ import round from 'lodash-es/round.js';
 /**
  * Internal dependencies
  */
-import { getURLs, logURLProgress } from '../lib/cli/args.mjs';
+import { getURLs, shouldLogURLProgress } from '../lib/cli/args.mjs';
 import {
 	log,
 	formats,
@@ -162,7 +162,7 @@ export async function handler( opt ) {
 	const browser = await puppeteer.launch( { headless: 'new' } );
 
 	// Log progress only under certain conditions (multiple URLs to benchmark).
-	const logProgress = logURLProgress( opt );
+	const logProgress = shouldLogURLProgress( opt );
 
 	for await ( const url of getURLs( opt ) ) {
 		if ( logProgress ) {

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -663,7 +663,7 @@ function outputResults( opt, results ) {
 						? round(
 								calcStandardDeviation(
 									metrics[ metricName ],
-									1
+									true
 								),
 								2
 						  )

--- a/cli/commands/wpt-metrics.mjs
+++ b/cli/commands/wpt-metrics.mjs
@@ -26,6 +26,7 @@ import round from 'lodash-es/round.js';
  */
 import {
 	log,
+	output,
 	formats,
 	table,
 	isValidTableFormat,
@@ -179,7 +180,7 @@ export async function handler( opt ) {
 		};
 	}
 
-	log(
+	output(
 		table(
 			headings,
 			mergedResultMetrics.map( parseTableData ),

--- a/cli/commands/wpt-server-timing.mjs
+++ b/cli/commands/wpt-server-timing.mjs
@@ -26,6 +26,7 @@ import round from 'lodash-es/round.js';
  */
 import {
 	log,
+	output,
 	formats,
 	table,
 	isValidTableFormat,
@@ -163,7 +164,7 @@ export async function handler( opt ) {
 		};
 	}
 
-	log(
+	output(
 		table(
 			headings,
 			mergedResultMetrics.map( parseTableData ),

--- a/cli/lib/cli/args.mjs
+++ b/cli/lib/cli/args.mjs
@@ -61,6 +61,6 @@ export async function* getURLs( opt ) {
 	}
 }
 
-export function logURLProgress( opt ) {
+export function shouldLogURLProgress( opt ) {
 	return ! opt.url && !! opt.file;
 }

--- a/cli/lib/cli/args.mjs
+++ b/cli/lib/cli/args.mjs
@@ -64,3 +64,7 @@ export async function* getURLs( opt ) {
 export function shouldLogURLProgress( opt ) {
 	return ! opt.url && !! opt.file;
 }
+
+export function shouldLogIterationsProgress( opt ) {
+	return opt.number && opt.number > 1;
+}

--- a/cli/lib/cli/args.mjs
+++ b/cli/lib/cli/args.mjs
@@ -60,3 +60,7 @@ export async function* getURLs( opt ) {
 		}
 	}
 }
+
+export function logURLProgress( opt ) {
+	return ! opt.url && !! opt.file;
+}

--- a/cli/lib/cli/logger.mjs
+++ b/cli/lib/cli/logger.mjs
@@ -23,7 +23,20 @@ import chalk from 'chalk';
 import { table as formatTable } from 'table';
 import { stringify as formatCsv } from 'csv-stringify/sync'; // eslint-disable-line import/no-unresolved
 
-export const log = console.log; // eslint-disable-line no-console
+// Responsible for the actual command output.
+export const output = ( text ) => {
+	process.stdout.write( `${ text }\n` );
+};
+
+// Responsible for (debug) logging.
+export const log = ( text ) => {
+	process.stderr.write( `${ text }\n` );
+};
+
+// Responsible for (debug) logging without "terminating" the line.
+export const logPartial = ( text ) => {
+	process.stderr.write( text );
+};
 
 export const formats = {
 	title: chalk.bold,


### PR DESCRIPTION
This PR enhances the `benchmark-server-timing` and `benchmark-web-vitals` commands in two ways:
1. In case a file is provided (i.e. most likely multiple URLs are being benchmarked), the commands will now log progress.
2. Errors in the process are now caught, which is particularly relevant for `benchmark-web-vitals`. Puppeteer errors such as navigation timeouts could otherwise lead to the entire process getting stuck.

While logging isn't really needed for benchmarking a single URL, when benchmarking several URLs the lack of it is a poor experience, as you have no idea on the progress. The second point is particularly relevant for that, as without that it could be possible for that progress to even get completely stuck, and you would never find out about it.