### PR TITLE
Add support for reporting variance in benchmarks

### DIFF
--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -33,7 +33,11 @@ import {
 	isValidTableFormat,
 	OUTPUT_FORMAT_TABLE,
 } from '../lib/cli/logger.mjs';
-import { calcPercentile, calcStandardDeviation } from '../lib/util/math.mjs';
+import {
+	calcPercentile,
+	calcStandardDeviation,
+	calcMedianAbsoluteDeviation,
+} from '../lib/util/math.mjs';
 import {
 	KEY_PERCENTILES,
 	MEDIAN_PERCENTILES,
@@ -213,6 +217,7 @@ function outputResults( opt, results ) {
 
 		if ( opt.showVariance ) {
 			headings.push( 'Response Time (SD)' );
+			headings.push( 'Response Time (MAD)' );
 			headings.push( 'Response Time (IQR)' );
 		}
 
@@ -222,6 +227,7 @@ function outputResults( opt, results ) {
 			} );
 			if ( opt.showVariance ) {
 				headings.push( `${ metricName } (SD)` );
+				headings.push( `${ metricName } (MAD)` );
 				headings.push( `${ metricName } (IQR)` );
 			}
 		} );
@@ -229,6 +235,7 @@ function outputResults( opt, results ) {
 		headings.push( 'Response Time (median)' );
 		if ( opt.showVariance ) {
 			headings.push( 'Response Time (SD)' );
+			headings.push( 'Response Time (MAD)' );
 			headings.push( 'Response Time (IQR)' );
 		}
 
@@ -236,6 +243,7 @@ function outputResults( opt, results ) {
 			headings.push( `${ metricName } (median)` );
 			if ( opt.showVariance ) {
 				headings.push( `${ metricName } (SD)` );
+				headings.push( `${ metricName } (MAD)` );
 				headings.push( `${ metricName } (IQR)` );
 			}
 		} );
@@ -261,6 +269,9 @@ function outputResults( opt, results ) {
 		if ( opt.showVariance ) {
 			tableRow.push(
 				round( calcStandardDeviation( responseTimes, 1 ), 2 )
+			);
+			tableRow.push(
+				round( calcMedianAbsoluteDeviation( responseTimes ), 2 )
 			);
 			tableRow.push(
 				round(
@@ -292,6 +303,16 @@ function outputResults( opt, results ) {
 								calcStandardDeviation(
 									metrics[ metricName ],
 									1
+								),
+								2
+						  )
+						: ''
+				);
+				tableRow.push(
+					metrics[ metricName ]
+						? round(
+								calcMedianAbsoluteDeviation(
+									metrics[ metricName ]
 								),
 								2
 						  )

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -227,8 +227,17 @@ function outputResults( opt, results ) {
 		} );
 	} else {
 		headings.push( 'Response Time (median)' );
+		if ( opt.showVariance ) {
+			headings.push( 'Response Time (SD)' );
+			headings.push( 'Response Time (IQR)' );
+		}
+
 		Object.keys( allMetricNames ).forEach( ( metricName ) => {
 			headings.push( `${ metricName } (median)` );
+			if ( opt.showVariance ) {
+				headings.push( `${ metricName } (SD)` );
+				headings.push( `${ metricName } (IQR)` );
+			}
 		} );
 	}
 

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -219,12 +219,11 @@ function outputResults( opt, results ) {
 		Object.keys( allMetricNames ).forEach( ( metricName ) => {
 			percentiles.forEach( ( percentile ) => {
 				headings.push( `${ metricName } (p${ percentile })` );
-
-				if ( opt.showVariance ) {
-					headings.push( `${ metricName } (SD)` );
-					headings.push( `${ metricName } (IQR)` );
-				}
 			} );
+			if ( opt.showVariance ) {
+				headings.push( `${ metricName } (SD)` );
+				headings.push( `${ metricName } (IQR)` );
+			}
 		} );
 	} else {
 		headings.push( 'Response Time (median)' );

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -451,7 +451,7 @@ function outputResults( opt, results ) {
 					metrics[ metricName ]
 						? round(
 								calcMedianAbsoluteDeviation(
-									metrics[ metricName ],
+									metrics[ metricName ]
 								),
 								2
 						  )

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -38,7 +38,11 @@ import {
 	isValidTableFormat,
 	OUTPUT_FORMAT_TABLE,
 } from '../lib/cli/logger.mjs';
-import { calcPercentile, calcStandardDeviation } from '../lib/util/math.mjs';
+import {
+	calcPercentile,
+	calcStandardDeviation,
+	calcMedianAbsoluteDeviation,
+} from '../lib/util/math.mjs';
 import {
 	KEY_PERCENTILES,
 	MEDIAN_PERCENTILES,
@@ -392,6 +396,7 @@ function outputResults( opt, results ) {
 			} );
 			if ( opt.showVariance ) {
 				headings.push( `${ metricName } (SD)` );
+				headings.push( `${ metricName } (MAD)` );
 				headings.push( `${ metricName } (IQR)` );
 			}
 		} );
@@ -400,6 +405,7 @@ function outputResults( opt, results ) {
 			headings.push( `${ metricName } (median)` );
 			if ( opt.showVariance ) {
 				headings.push( `${ metricName } (SD)` );
+				headings.push( `${ metricName } (MAD)` );
 				headings.push( `${ metricName } (IQR)` );
 			}
 		} );
@@ -436,6 +442,16 @@ function outputResults( opt, results ) {
 								calcStandardDeviation(
 									metrics[ metricName ],
 									1
+								),
+								2
+						  )
+						: ''
+				);
+				tableRow.push(
+					metrics[ metricName ]
+						? round(
+								calcMedianAbsoluteDeviation(
+									metrics[ metricName ],
 								),
 								2
 						  )

--- a/cli/lib/util/math.mjs
+++ b/cli/lib/util/math.mjs
@@ -67,5 +67,5 @@ export function calcStandardDeviation( arr, usePopulation = false ) {
 export function calcMedianAbsoluteDeviation( values ) {
 	const median = calcMedian( values );
 
-	return calcMedian( values.map( value => Math.abs( value - median ) ) );
+	return calcMedian( values.map( ( value ) => Math.abs( value - median ) ) );
 }

--- a/cli/lib/util/math.mjs
+++ b/cli/lib/util/math.mjs
@@ -53,3 +53,13 @@ export function calcPercentile( percentile, values ) {
 export function calcMedian( values ) {
 	return calcPercentile( 50, values );
 }
+
+export function calcStandardDeviation( arr, usePopulation = false ) {
+	const mean = arr.reduce( ( acc, val ) => acc + val, 0 ) / arr.length;
+	return Math.sqrt(
+		arr
+			.reduce( ( acc, val ) => acc.concat( ( val - mean ) ** 2 ), [] )
+			.reduce( ( acc, val ) => acc + val, 0 ) /
+			( arr.length - ( usePopulation ? 0 : 1 ) )
+	);
+}

--- a/cli/lib/util/math.mjs
+++ b/cli/lib/util/math.mjs
@@ -63,3 +63,9 @@ export function calcStandardDeviation( arr, usePopulation = false ) {
 			( arr.length - ( usePopulation ? 0 : 1 ) )
 	);
 }
+
+export function calcMedianAbsoluteDeviation( values ) {
+	const median = calcMedian( values );
+
+	return calcMedian( values.map( value => Math.abs( value - median ) ) );
+}


### PR DESCRIPTION
This adds a new CLI arg to both the benchmark CLI commands that will report the standard deviation (SD) and interquartile range (IQR) for a set of results by passing either `-v` or `--show-variance` as an argument when running a benchmark command.

Example:

```
npm run research benchmark-server-timing -- -u http://localhost:8889/ -p -n 100 -v

╔═════════════════════╤════════════════════════╗
║ URL                 │ http://localhost:8889/ ║
╟─────────────────────┼────────────────────────╢
║ Success Rate        │ 100%                   ║
╟─────────────────────┼────────────────────────╢
║ Response Time (p10) │ 131.22                 ║
╟─────────────────────┼────────────────────────╢
║ Response Time (p25) │ 136.7                  ║
╟─────────────────────┼────────────────────────╢
║ Response Time (p50) │ 142.71                 ║
╟─────────────────────┼────────────────────────╢
║ Response Time (p75) │ 147.52                 ║
╟─────────────────────┼────────────────────────╢
║ Response Time (p90) │ 159.02                 ║
╟─────────────────────┼────────────────────────╢
║ Response Time (SD)  │ 26.7                   ║
╟─────────────────────┼────────────────────────╢
║ Response Time (IQR) │ 10.82                  ║
╚═════════════════════╧════════════════════════╝
```