### PR TITLE
Add query for the counts of embed blocks on root and non-root pages

### DIFF
--- a/sql/2024/01/embed-blocks-on-root-and-non-root-pages.sql
+++ b/sql/2024/01/embed-blocks-on-root-and-non-root-pages.sql
@@ -1,0 +1,31 @@
+# HTTP Archive query to get scripts blocking in head, counted by plugin.
+#
+# WPP Research, Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+SELECT
+  is_root_page,
+  JSON_EXTRACT(custom_metrics, '$.cms.wordpress.has_embed_block') AS has_embed_block,
+  COUNT(*) AS page_count,
+  ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER (), 1) AS percentage_of_total
+FROM
+  `httparchive.all.pages`,
+  UNNEST(technologies) AS technology
+WHERE
+  date = CAST('2023-12-01' AS DATE)
+  AND technology.technology = 'WordPress'
+GROUP BY
+  has_embed_block,
+  is_root_page
+ORDER BY percentage_of_total DESC

--- a/sql/2024/01/embed-blocks-on-root-and-non-root-pages.sql
+++ b/sql/2024/01/embed-blocks-on-root-and-non-root-pages.sql
@@ -14,6 +14,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/84
+
 SELECT
   is_root_page,
   JSON_EXTRACT(custom_metrics, '$.cms.wordpress.has_embed_block') AS has_embed_block,

--- a/sql/README.md
+++ b/sql/README.md
@@ -23,6 +23,7 @@ For additional considerations for writing BigQuery queries against HTTP Archive,
 ### 2024/01
 
 * [TTFB of localized WordPress sites](./2024/01/ttfb-localized-sites.sql)
+* [Embed blocks on root and non-root pages](./2024/01/embed-blocks-on-root-and-non-root-pages.sql)
 
 ### 2023/10
 


### PR DESCRIPTION
For the oEmbed Optimizer project (https://github.com/WordPress/performance/pull/886), I was curious if the count of embeds on non-root pages would be significantly higher. Well, it is _more_ common but only slightly:

is_root_page | has_embed_block | page_count | percentage_of_total
-- | -- | -- | --
TRUE | FALSE | 9858816 | 51.1
FALSE | FALSE | 9190040 | 47.6
FALSE | TRUE | 150877 | 0.8
TRUE | TRUE | 109338 | 0.6

According to this, root pages have embed blocks **1.09%** of the time (109338/(109338+9858816), and non-root pages have them **1.61%** of the time (150877/(150877+9190040)), so %0.52 more often.