### PR TITLE
Update inaccurate sizes query for 2024

### DIFF
--- a/sql/2024/04/inaccurate-sizes-attribute-impact.sql
+++ b/sql/2024/04/inaccurate-sizes-attribute-impact.sql
@@ -16,7 +16,9 @@
 
 
 CREATE TEMPORARY FUNCTION GET_IMG_SIZES_ACCURACY(custom_metrics STRING) RETURNS
-  ARRAY<STRUCT<sizesAbsoluteError INT64,
+  ARRAY<STRUCT<hasSrcset BOOL,
+  hasSizes BOOL,
+  sizesAbsoluteError INT64,
   sizesRelativeError FLOAT64,
   idealSizesSelectedResourceEstimatedPixels INT64,
   actualSizesEstimatedWastedLoadedPixels INT64,
@@ -25,6 +27,8 @@ CREATE TEMPORARY FUNCTION GET_IMG_SIZES_ACCURACY(custom_metrics STRING) RETURNS
 AS (
   ARRAY(
     SELECT AS STRUCT
+      CAST(JSON_EXTRACT_SCALAR(image, '$.hasSrcset') AS BOOL) AS hasSrcset,
+      CAST(JSON_EXTRACT_SCALAR(image, '$.hasSizes') AS BOOL) AS hasSizes,
       CAST(JSON_EXTRACT_SCALAR(image, '$.sizesAbsoluteError') AS INT64) AS sizesAbsoluteError,
       CAST(JSON_EXTRACT_SCALAR(image, '$.sizesRelativeError') AS FLOAT64) AS sizesRelativeError,
       CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedPixels') AS INT64) AS idealSizesSelectedResourceEstimatedPixels,
@@ -59,6 +63,8 @@ WITH wordpressSizesData AS (
     date = '2024-03-01'
     AND IS_CMS(technologies, 'WordPress', '')
     AND is_root_page = TRUE
+    AND image.hasSrcset = TRUE
+    AND image.hasSizes = TRUE
 )
 
 SELECT

--- a/sql/2024/04/inaccurate-sizes-attribute-impact.sql
+++ b/sql/2024/04/inaccurate-sizes-attribute-impact.sql
@@ -37,14 +37,14 @@ AS (
       CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedPixels') AS INT64) AS idealSizesSelectedResourceEstimatedPixels,
       CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedPixels') AS INT64) AS actualSizesEstimatedWastedLoadedPixels,
       SAFE_DIVIDE(
-        CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedPixels') AS INT64),
-        CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedPixels') AS INT64)
+        CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedPixels') AS INT64),
+        CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedPixels') AS INT64)
       ) AS relativeSizesEstimatedWastedLoadedPixels,
       CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedBytes') AS FLOAT64) AS idealSizesSelectedResourceEstimatedBytes,
       CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedBytes') AS FLOAT64) AS actualSizesEstimatedWastedLoadedBytes,
       SAFE_DIVIDE(
-        CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedBytes') AS FLOAT64),
-        CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedBytes') AS FLOAT64)
+        CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedBytes') AS FLOAT64),
+        CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedBytes') AS FLOAT64)
       ) AS relativeSizesEstimatedWastedLoadedBytes,
     FROM
       UNNEST(JSON_EXTRACT_ARRAY(custom_metrics, '$.responsive_images.responsive-images')) AS image

--- a/sql/2024/04/inaccurate-sizes-attribute-impact.sql
+++ b/sql/2024/04/inaccurate-sizes-attribute-impact.sql
@@ -19,7 +19,7 @@ DECLARE DATE_TO_QUERY DATE DEFAULT '2024-03-01';
 CREATE TEMPORARY FUNCTION GET_IMG_SIZES_ACCURACY(custom_metrics STRING) RETURNS
   ARRAY<STRUCT<hasSrcset BOOL,
   hasSizes BOOL,
-  sizesAbsoluteError INT64,
+  sizesAbsoluteError FLOAT64,
   sizesRelativeError FLOAT64,
   idealSizesSelectedResourceEstimatedPixels INT64,
   actualSizesEstimatedWastedLoadedPixels INT64,
@@ -32,7 +32,7 @@ AS (
     SELECT AS STRUCT
       CAST(JSON_EXTRACT_SCALAR(image, '$.hasSrcset') AS BOOL) AS hasSrcset,
       CAST(JSON_EXTRACT_SCALAR(image, '$.hasSizes') AS BOOL) AS hasSizes,
-      CAST(JSON_EXTRACT_SCALAR(image, '$.sizesAbsoluteError') AS INT64) AS sizesAbsoluteError,
+      CAST(JSON_EXTRACT_SCALAR(image, '$.sizesAbsoluteError') AS FLOAT64) AS sizesAbsoluteError,
       CAST(JSON_EXTRACT_SCALAR(image, '$.sizesRelativeError') AS FLOAT64) AS sizesRelativeError,
       CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedPixels') AS INT64) AS idealSizesSelectedResourceEstimatedPixels,
       CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedPixels') AS INT64) AS actualSizesEstimatedWastedLoadedPixels,

--- a/sql/2024/04/inaccurate-sizes-attribute-impact.sql
+++ b/sql/2024/04/inaccurate-sizes-attribute-impact.sql
@@ -98,5 +98,5 @@ GROUP BY
   percentile,
   client
 ORDER BY
-  percentile,
-  client
+  client,
+  percentile

--- a/sql/2024/04/inaccurate-sizes-attribute-impact.sql
+++ b/sql/2024/04/inaccurate-sizes-attribute-impact.sql
@@ -14,6 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+DECLARE DATE_TO_QUERY DATE DEFAULT '2024-03-01';
 
 CREATE TEMPORARY FUNCTION GET_IMG_SIZES_ACCURACY(custom_metrics STRING) RETURNS
   ARRAY<STRUCT<hasSrcset BOOL,
@@ -70,7 +71,7 @@ WITH wordpressSizesData AS (
     `httparchive.all.pages`,
     UNNEST(GET_IMG_SIZES_ACCURACY(custom_metrics)) AS image
   WHERE
-    date = '2024-03-01'
+    date = DATE_TO_QUERY
     AND IS_CMS(technologies, 'WordPress', '')
     AND is_root_page = TRUE
     AND image.hasSrcset = TRUE

--- a/sql/2024/04/inaccurate-sizes-attribute-impact.sql
+++ b/sql/2024/04/inaccurate-sizes-attribute-impact.sql
@@ -1,0 +1,106 @@
+# HTTP Archive query to measure impact of inaccurate sizes attributes per <img> for WordPress sites.
+#
+# WPP Research, Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+CREATE TEMPORARY FUNCTION
+  getSrcsetSizesAccuracy(payload STRING)
+  RETURNS ARRAY<STRUCT<sizesAbsoluteError INT64,
+  sizesRelativeError FLOAT64,
+  wDescriptorAbsoluteError INT64,
+  wDescriptorRelativeError FLOAT64,
+  actualSizesEstimatedWastedLoadedPixels INT64,
+  actualSizesEstimatedWastedLoadedBytes FLOAT64,
+  wastedLoadedPercent FLOAT64>>
+  LANGUAGE js AS '''
+try {
+  var $ = JSON.parse(payload);
+  var responsiveImages = JSON.parse($._responsive_images);
+  responsiveImages = responsiveImages['responsive-images'];
+  return responsiveImages.map(({
+    sizesAbsoluteError,
+    sizesRelativeError,
+    wDescriptorAbsoluteError,
+    wDescriptorRelativeError,
+    idealSizesSelectedResourceEstimatedPixels,
+    actualSizesEstimatedWastedLoadedPixels,
+    actualSizesEstimatedWastedLoadedBytes
+  }) => {
+    let wastedLoadedPercent;
+    if ( idealSizesSelectedResourceEstimatedPixels > 0 ) {
+      wastedLoadedPercent = actualSizesEstimatedWastedLoadedPixels / idealSizesSelectedResourceEstimatedPixels;
+    } else {
+      wastedLoadedPercent = null;
+    }
+    return {
+      sizesAbsoluteError,
+      sizesRelativeError,
+      wDescriptorAbsoluteError,
+      wDescriptorRelativeError,
+      actualSizesEstimatedWastedLoadedPixels,
+      actualSizesEstimatedWastedLoadedBytes,
+      wastedLoadedPercent
+    };
+  }
+);
+} catch (e) {
+  return [];
+}
+''';
+
+CREATE TEMPORARY FUNCTION IS_CMS(technologies ARRAY<STRUCT<technology STRING, categories ARRAY<STRING>, info ARRAY<STRING>>>, cms STRING, version STRING) RETURNS BOOL AS (
+  EXISTS(
+    SELECT * FROM UNNEST(technologies) AS technology, UNNEST(technology.info) AS info
+    WHERE technology.technology = cms
+    AND (
+      version = ""
+      OR ENDS_WITH(version, ".x") AND (STARTS_WITH(info, RTRIM(version, "x")) OR info = RTRIM(version, ".x"))
+      OR info = version
+    )
+  )
+);
+
+WITH wordpressSizesData AS (
+  SELECT
+    client,
+    image
+  FROM
+    `httparchive.all.pages`,
+    UNNEST(getSrcsetSizesAccuracy(payload)) AS image
+  WHERE
+    date = '2024-02-01'
+    AND IS_CMS(technologies, 'WordPress', '')
+    AND is_root_page = TRUE
+)
+
+SELECT
+  percentile,
+  client,
+  APPROX_QUANTILES(image.sizesAbsoluteError, 100)[OFFSET(percentile)] AS sizesAbsoluteError,
+  APPROX_QUANTILES(image.sizesRelativeError, 100)[OFFSET(percentile)] AS sizesRelativeError,
+  APPROX_QUANTILES(image.wDescriptorAbsoluteError, 100)[OFFSET(percentile)] AS wDescriptorAbsoluteError,
+  APPROX_QUANTILES(image.wDescriptorRelativeError, 100)[OFFSET(percentile)] AS wDescriptorRelativeError,
+  APPROX_QUANTILES(image.actualSizesEstimatedWastedLoadedPixels, 100)[OFFSET(percentile)] AS actualSizesEstimatedWastedLoadedPixels,
+  APPROX_QUANTILES(image.actualSizesEstimatedWastedLoadedBytes, 100)[OFFSET(percentile)] AS actualSizesEstimatedWastedLoadedBytes,
+  APPROX_QUANTILES(image.wastedLoadedPercent, 100)[OFFSET(percentile)] AS wastedLoadedPercent
+FROM
+  wordpressSizesData,
+  UNNEST([10, 20, 30, 40, 50, 60, 70, 80, 90]) AS percentile
+GROUP BY
+  percentile,
+  client
+ORDER BY
+  percentile,
+  client

--- a/sql/2024/04/inaccurate-sizes-attribute-impact.sql
+++ b/sql/2024/04/inaccurate-sizes-attribute-impact.sql
@@ -13,6 +13,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
+# See https://github.com/GoogleChromeLabs/wpp-research/pull/108
 
 DECLARE DATE_TO_QUERY DATE DEFAULT '2024-03-01';
 

--- a/sql/README.md
+++ b/sql/README.md
@@ -20,6 +20,9 @@ For additional considerations for writing BigQuery queries against HTTP Archive,
 
 ## Query index
 
+### 2024/04
+* [Impact of inaccurate sizes attributes in WordPress](./2024/04/inaccurate-sizes-attribute-impact.sql)
+
 ### 2024/01
 
 * [TTFB of localized WordPress sites](./2024/01/ttfb-localized-sites.sql)


### PR DESCRIPTION
This is an update to the previous query created in 2022 to evaluate the impact of inaccurate image sizes attributes on WordPress sites using HTTPArchive data.

The main changes from the original query are:

- Updates the query to use the new `httparchive.all.pages` table.
- Reports percentages at every 10th percentile rather than only 10, 25, 50, 75, and 90.

See: https://github.com/GoogleChromeLabs/wpp-research/blob/main/sql/2022/12/inaccurate-sizes-attribute-impact.sql

## Query results

percentile | client | sizesAbsoluteError | sizesRelativeError | idealSizesSelectedResourceEstimatedPixels | actualSizesEstimatedWastedLoadedPixels | relativeSizesEstimatedWastedLoadedPixels | idealSizesSelectedResourceEstimatedBytes | actualSizesEstimatedWastedLoadedBytes | relativeSizesEstimatedWastedLoadedBytes
-- | -- | -- | -- | -- | -- | -- | -- | -- | --
10 | desktop | 0 | 0.00% | 22500 | 0 | 0.00% | 3217.294704 | 0 | 0.00%
20 | desktop | 0 | 0.00% | 38700 | 0 | 0.00% | 6348.266602 | 0 | 0.00%
30 | desktop | 30 | 2.56% | 60000 | 0 | 0.00% | 10174 | 0 | 0.00%
40 | desktop | 92 | 21.15% | 81510 | 0 | 0.00% | 15106.58125 | 0 | 0.00%
50 | desktop | 168 | 46.75% | 90000 | 0 | 0.00% | 22073.49726 | 0 | 0.00%
60 | desktop | 287 | 76.47% | 150000 | 959 | 0.83% | 33262 | 283.5713028 | 0.83%
70 | desktop | 403 | 117.39% | 240000 | 76464 | 77.78% | 51765 | 11312.8272 | 77.78%
80 | desktop | 600 | 190.91% | 360000 | 258560 | 221.92% | 84253 | 37755.31432 | 221.92%
90 | desktop | 934 | 344.44% | 559872 | 633600 | 611.11% | 166977.4965 | 114393.7302 | 611.11%
10 | mobile | 0 | 0.00% | 32400 | 0 | 0.00% | 5159.87395 | 0 | 0.00%
20 | mobile | 13 | 0.00% | 62500 | 0 | 0.00% | 10203.16195 | 0 | 0.00%
30 | mobile | 31 | 8.43% | 90000 | 0 | 0.00% | 16965.07937 | 0 | 0.00%
40 | mobile | 50 | 12.50% | 147456 | 0 | 0.00% | 26480.16 | 0 | 0.00%
50 | mobile | 72 | 19.21% | 230400 | 0 | 0.00% | 40172.8267 | 0 | 0.00%
60 | mobile | 136 | 29.50% | 320000 | 0 | 0.00% | 59071.69489 | 0 | 0.00%
70 | mobile | 192 | 66.67% | 421888 | 27900 | 13.78% | 85978.125 | 3595.061728 | 13.78%
80 | mobile | 244 | 115.22% | 589824 | 227500 | 124.84% | 130197.1576 | 26660.31658 | 124.84%
90 | mobile | 360 | 168.66% | 786432 | 504000 | 440.83% | 242668 | 77222.4375 | 440.83%
