### PR TITLE
Implement query to get diff for Web Vitals from using `script[type="speculationrules"]`

### DIFF
--- a/sql/2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql
+++ b/sql/2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql
@@ -1,0 +1,119 @@
+# HTTP Archive query to get diff for Web Vitals passing rates of sites that enabled the Speculation Rules API from one month to the next.
+#
+# WPP Research, Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# See https://github.com/GoogleChromeLabs/wpp-research/pull/112
+CREATE TEMP FUNCTION GET_SPECULATIONRULES(custom_metrics STRING) RETURNS STRING AS (
+  (
+    SELECT
+      script
+    FROM
+      UNNEST(JSON_EXTRACT_ARRAY(custom_metrics, "$.almanac.scripts.nodes")) AS script
+    WHERE
+      LOWER(JSON_EXTRACT_SCALAR(script, "$.type")) = 'speculationrules'
+    LIMIT
+      1
+  )
+);
+
+CREATE TEMP FUNCTION GET_ORIGIN_NAV_PASS_RATE(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS FLOAT64 AS (
+  SAFE_DIVIDE(good, good + needs_improvement + poor)
+);
+
+CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  SAFE_DIVIDE(good, good + needs_improvement + poor) >= 0.75
+);
+
+CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
+  good + needs_improvement + poor > 0
+);
+
+WITH newUrlsWithSpeculationRules AS (
+  SELECT
+    date,
+    client,
+    page
+  FROM
+    `httparchive.all.pages`
+  WHERE
+    date = '2024-02-01'
+    AND is_root_page
+    AND GET_SPECULATIONRULES(custom_metrics) IS NOT NULL
+),
+
+urlsWhichEnabledSpeculationRules AS (
+  SELECT
+    IF(client = 'mobile', 'phone', 'desktop') AS device,
+    TRIM(page, '/') AS origin
+  FROM
+    `httparchive.all.pages` p
+  INNER JOIN
+    newUrlsWithSpeculationRules
+  USING
+    (client, page)
+  WHERE
+    p.date = '2024-01-01'
+    AND is_root_page
+    AND GET_SPECULATIONRULES(custom_metrics) IS NULL
+),
+
+crux AS (
+  SELECT
+    date,
+    device,
+    origin,
+
+    # Web Vitals nav pass rates per origin
+    GET_ORIGIN_NAV_PASS_RATE(fast_lcp, avg_lcp, slow_lcp) AS lcp_pass_rate,
+    GET_ORIGIN_NAV_PASS_RATE(fast_inp, avg_inp, slow_inp) AS inp_pass_rate,
+    GET_ORIGIN_NAV_PASS_RATE(small_cls, medium_cls, large_cls) AS cls_pass_rate,
+    GET_ORIGIN_NAV_PASS_RATE(fast_fcp, avg_fcp, slow_fcp) AS fcp_pass_rate,
+    GET_ORIGIN_NAV_PASS_RATE(fast_ttfb, avg_ttfb, slow_ttfb) AS ttfb_pass_rate,
+    GET_ORIGIN_NAV_PASS_RATE(fast_fid, avg_fid, slow_fid) AS fid_pass_rate
+  FROM
+    `chrome-ux-report.materialized.device_summary`
+  INNER JOIN
+    urlsWhichEnabledSpeculationRules
+  USING
+    (device, origin)
+  WHERE
+    (date = '2024-01-01' OR date = '2024-02-01')
+    AND device IN ('desktop', 'phone')
+)
+
+SELECT
+  device,
+  oldCrux.date AS oldDate,
+  newCrux.date AS newDate,
+  COUNT(origin) AS num_origins,
+  percentile,
+  APPROX_QUANTILES(newCrux.lcp_pass_rate - oldCrux.lcp_pass_rate, 100)[OFFSET(percentile)] AS lcp_diff,
+  APPROX_QUANTILES(newCrux.inp_pass_rate - oldCrux.inp_pass_rate, 100)[OFFSET(percentile)] AS inp_diff,
+  APPROX_QUANTILES(newCrux.cls_pass_rate - oldCrux.cls_pass_rate, 100)[OFFSET(percentile)] AS cls_diff,
+  APPROX_QUANTILES(newCrux.fcp_pass_rate - oldCrux.fcp_pass_rate, 100)[OFFSET(percentile)] AS fcp_diff,
+  APPROX_QUANTILES(newCrux.ttfb_pass_rate - oldCrux.ttfb_pass_rate, 100)[OFFSET(percentile)] AS ttfb_diff,
+  APPROX_QUANTILES(newCrux.fid_pass_rate - oldCrux.fid_pass_rate, 100)[OFFSET(percentile)] AS fid_diff
+FROM (
+  SELECT * FROM crux WHERE date = '2024-01-01'
+) oldCrux, UNNEST([10, 25, 50, 75, 90, 100]) AS percentile
+INNER JOIN (
+  SELECT * FROM crux WHERE date = '2024-02-01'
+) newCrux
+USING
+  (device, origin)
+GROUP BY
+  device,
+  oldDate,
+  newDate,
+  percentile

--- a/sql/2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql
+++ b/sql/2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # See https://github.com/GoogleChromeLabs/wpp-research/pull/112
-DECLARE DATE_TO_QUERY DATE DEFAULT '2024-02-01';
+DECLARE DATE_TO_QUERY DATE DEFAULT '2024-03-01';
 
 DECLARE DATE_TO_COMPARE DATE DEFAULT DATE_SUB(DATE_TO_QUERY, INTERVAL 1 MONTH);
 

--- a/sql/2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql
+++ b/sql/2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql
@@ -31,14 +31,6 @@ CREATE TEMP FUNCTION GET_ORIGIN_NAV_PASS_RATE(good FLOAT64, needs_improvement FL
   SAFE_DIVIDE(good, good + needs_improvement + poor)
 );
 
-CREATE TEMP FUNCTION IS_GOOD(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
-  SAFE_DIVIDE(good, good + needs_improvement + poor) >= 0.75
-);
-
-CREATE TEMP FUNCTION IS_NON_ZERO(good FLOAT64, needs_improvement FLOAT64, poor FLOAT64) RETURNS BOOL AS (
-  good + needs_improvement + poor > 0
-);
-
 WITH newUrlsWithSpeculationRules AS (
   SELECT
     date,

--- a/sql/2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql
+++ b/sql/2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql
@@ -117,3 +117,6 @@ GROUP BY
   oldDate,
   newDate,
   percentile
+ORDER BY
+  device,
+  percentile

--- a/sql/README.md
+++ b/sql/README.md
@@ -20,6 +20,10 @@ For additional considerations for writing BigQuery queries against HTTP Archive,
 
 ## Query index
 
+### 2024/04
+
+* [Diff for Web Vitals passing rates of sites that enabled the Speculation Rules API from one month to the next](./2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql)
+
 ### 2024/01
 
 * [TTFB of localized WordPress sites](./2024/01/ttfb-localized-sites.sql)


### PR DESCRIPTION
This query compares the Web Vitals passing rate per origin, for only origins that are using the Speculation Rules API (via `script[type="speculationrules"]`), but were not using it in the month before. The idea is that this should give a glimpse of potential impact.

Note that the dataset is still relatively small. This may be better in the future as more WordPress sites adopt the [Speculative Loading plugin](https://wordpress.org/plugins/speculation-rules/).

Worth noting that the query is not limited to WordPress sites, as that in principle gives us a larger dataset, and the goal of this query is not to make a WordPress-specific, but rather a general assessment on the API and its usage.

device | oldDate | newDate | num_origins | percentile | lcp_diff | inp_diff | cls_diff | fcp_diff | ttfb_diff | fid_diff
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
desktop | 2024-02-01 | 2024-03-01 | 4312 | 10 | -4.53% | -3.16% | -2.94% | -2.65% | -3.72% | -2.24%
desktop | 2024-02-01 | 2024-03-01 | 4312 | 25 | -2.09% | -1.40% | -0.10% | -1.00% | -1.30% | -1.22%
desktop | 2024-02-01 | 2024-03-01 | 4312 | 50 | 0.21% | -0.09% | 2.66% | 0.45% | 0.96% | -0.40%
desktop | 2024-02-01 | 2024-03-01 | 4312 | 75 | 2.91% | 1.25% | 5.74% | 2.23% | 4.27% | 0.37%
desktop | 2024-02-01 | 2024-03-01 | 4312 | 90 | 5.97% | 2.89% | 9.34% | 4.48% | 8.30% | 1.25%
desktop | 2024-02-01 | 2024-03-01 | 4312 | 100 | 37.60% | 17.48% | 35.39% | 46.68% | 37.53% | 10.16%
phone | 2024-02-01 | 2024-03-01 | 595 | 10 | -4.47% | -5.99% | -3.79% | -2.70% | -4.53% | -4.31%
phone | 2024-02-01 | 2024-03-01 | 595 | 25 | -1.54% | -3.79% | -1.75% | -0.42% | -0.94% | -2.83%
phone | 2024-02-01 | 2024-03-01 | 595 | 50 | 0.55% | -1.69% | -0.40% | 0.90% | 0.89% | -1.62%
phone | 2024-02-01 | 2024-03-01 | 595 | 75 | 3.01% | 1.05% | 1.22% | 2.80% | 4.04% | -0.11%
phone | 2024-02-01 | 2024-03-01 | 595 | 90 | 7.64% | 4.37% | 3.27% | 6.47% | 9.51% | 1.24%
phone | 2024-02-01 | 2024-03-01 | 595 | 100 | 41.10% | 23.08% | 35.50% | 44.17% | 50.55% | 13.10%

