### PR TITLE
HTTP Archive query to get active install count for individual Performance Lab plugins (with and without Performance Lab present)

### DIFF
--- a/sql/2024/08/performance-lab-plugins-adoption.sql
+++ b/sql/2024/08/performance-lab-plugins-adoption.sql
@@ -1,0 +1,108 @@
+# HTTP Archive query to get active install counts for Performance Lab plugins
+# (with or without the Performance Lab plugin).
+#
+# WPP Research, Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# See https://github.com/GoogleChromeLabs/wpp-research/pull/97
+
+DECLARE
+  DATE_TO_QUERY DATE DEFAULT '2024-07-01';
+
+CREATE TEMPORARY FUNCTION HAS_TECHNOLOGY(technologies ARRAY<STRUCT<technology STRING, categories ARRAY<STRING>, info ARRAY<STRING>>>, technologyToFind STRING) RETURNS BOOL AS (
+  EXISTS(
+    SELECT
+      *
+    FROM
+      UNNEST(technologies) AS technology
+    WHERE technology.technology = technologyToFind
+  )
+);
+
+CREATE TEMPORARY FUNCTION GET_GENERATOR_CONTENTS(custom_metrics STRING) RETURNS ARRAY<STRING> AS (
+  ARRAY(
+    SELECT
+      JSON_EXTRACT_SCALAR(metaNode, '$.content') AS content
+    FROM
+      UNNEST(JSON_EXTRACT_ARRAY(JSON_EXTRACT(custom_metrics, '$.almanac.meta-nodes.nodes'))) AS metaNode
+    WHERE
+      JSON_EXTRACT_SCALAR(metaNode, '$.name') = 'generator'
+  )
+);
+
+CREATE TEMPORARY FUNCTION HAS_PERFORMANCE_LAB(contents ARRAY<STRING>) RETURNS BOOL AS (
+  EXISTS(
+    SELECT
+      *
+    FROM
+      UNNEST(contents) AS content
+    WHERE
+      STARTS_WITH(content, 'performance-lab ')
+  )
+);
+
+CREATE TEMPORARY FUNCTION EXTRACT_PL_PLUGINS_FROM_GENERATOR_CONTENTS(contents ARRAY<STRING>) RETURNS ARRAY<STRING> AS (
+  ARRAY(
+    SELECT
+      REGEXP_EXTRACT(content, '^([a-z0-9-]+) ') AS slug
+    FROM
+      UNNEST(contents) as content
+    WHERE
+      REGEXP_EXTRACT(content, '^([a-z0-9-]+) ') IN UNNEST([
+        'auto-sizes',
+        'dominant-color-images',
+        'embed-optimizer',
+        'image-prioritizer',
+        'optimization-detective',
+        'performant-translations', # Developed in separate repository.
+        'speculation-rules',
+        'web-worker-offloading',
+        'webp-uploads'
+      ])
+  )
+);
+
+WITH urlsWithPerformanceLabPlugins AS (
+  SELECT
+    client,
+    page,
+    # COUNT(DISTINCT page) OVER (PARTITION BY client) AS total,
+    HAS_PERFORMANCE_LAB(GET_GENERATOR_CONTENTS(custom_metrics)) AS has_pl,
+    EXTRACT_PL_PLUGINS_FROM_GENERATOR_CONTENTS(GET_GENERATOR_CONTENTS(custom_metrics)) AS plugins
+  FROM
+    `httparchive.all.pages`
+  WHERE
+    date = DATE_TO_QUERY
+    AND HAS_TECHNOLOGY(technologies, 'WordPress')
+    AND is_root_page = TRUE
+    AND ARRAY_LENGTH(EXTRACT_PL_PLUGINS_FROM_GENERATOR_CONTENTS(GET_GENERATOR_CONTENTS(custom_metrics))) > 0
+)
+
+SELECT
+  client,
+  plugin,
+  COUNT(DISTINCT page) AS urls,
+  COUNT(DISTINCT IF(has_pl = TRUE, page, NULL)) AS urls_with_pl,
+  COUNT(DISTINCT IF(has_pl = FALSE, page, NULL)) AS urls_without_pl
+  # ANY_VALUE(total) AS total,
+  # COUNT(DISTINCT page) / ANY_VALUE(total) AS pct_total
+FROM
+  urlsWithPerformanceLabPlugins,
+  UNNEST(plugins) AS plugin
+GROUP BY
+  client,
+  plugin
+ORDER BY
+  client,
+  urls DESC

--- a/sql/2024/08/performance-lab-plugins-adoption.sql
+++ b/sql/2024/08/performance-lab-plugins-adoption.sql
@@ -77,7 +77,6 @@ WITH urlsWithPerformanceLabPlugins AS (
   SELECT
     client,
     page,
-    # COUNT(DISTINCT page) OVER (PARTITION BY client) AS total,
     HAS_PERFORMANCE_LAB(GET_GENERATOR_CONTENTS(custom_metrics)) AS has_pl,
     EXTRACT_PL_PLUGINS_FROM_GENERATOR_CONTENTS(GET_GENERATOR_CONTENTS(custom_metrics)) AS plugins
   FROM
@@ -94,9 +93,8 @@ SELECT
   plugin,
   COUNT(DISTINCT page) AS urls,
   COUNT(DISTINCT IF(has_pl = TRUE, page, NULL)) AS urls_with_pl,
-  COUNT(DISTINCT IF(has_pl = FALSE, page, NULL)) AS urls_without_pl
-  # ANY_VALUE(total) AS total,
-  # COUNT(DISTINCT page) / ANY_VALUE(total) AS pct_total
+  COUNT(DISTINCT IF(has_pl = FALSE, page, NULL)) AS urls_without_pl,
+  COUNT(DISTINCT IF(has_pl = TRUE, page, NULL)) / COUNT(DISTINCT page) AS pct_with_pl
 FROM
   urlsWithPerformanceLabPlugins,
   UNNEST(plugins) AS plugin

--- a/sql/2024/08/performance-lab-plugins-adoption.sql
+++ b/sql/2024/08/performance-lab-plugins-adoption.sql
@@ -15,7 +15,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# See https://github.com/GoogleChromeLabs/wpp-research/pull/97
+# See https://github.com/GoogleChromeLabs/wpp-research/pull/146
 
 DECLARE
   DATE_TO_QUERY DATE DEFAULT '2024-07-01';

--- a/sql/README.md
+++ b/sql/README.md
@@ -20,6 +20,10 @@ For additional considerations for writing BigQuery queries against HTTP Archive,
 
 ## Query index
 
+### 2024/08
+
+* [Active install counts for Performance Lab plugins (with or without the Performance Lab plugin)](./2024/08/performance-lab-plugins-adoption.sql)
+
 ### 2024/04
 
 * [Diff for Web Vitals passing rates of sites that enabled the Speculation Rules API from one month to the next](./2024/04/web-vitals-diff-for-sites-enabling-speculation-rules.sql)


### PR DESCRIPTION
This query provides a list of all the individual "standalone" plugins that are part of the Performance Lab program (see https://github.com/WordPress/performance) and the number of sites they're used on.

While that by itself would just be a different angle to look at the "Active installs" counts that WordPress.org provides, the primary purpose is to get an idea of how commonly these plugins are used with or without the Performance Lab plugin present. As the latter has a much larger user base and acts partially as a funnel recommending the other plugins, the expectation would be that most sites use the other plugins in combination with Performance Lab, rather than coming across them independently of Performance Lab.

The results from this query confirm that for the most part (see below). The only exceptions are Performant Translations and Speculation Rules, which have seen a larger exposure through other channels (e.g. blog posts, social media).

## Query results


Row | client | plugin | urls | urls_with_pl | urls_without_pl | pct_with_pl
-- | -- | -- | -- | -- | -- | --
1 | desktop | webp-uploads | 10712 | 8795 | 1917 | 0.82104182225541444
2 | desktop | dominant-color-images | 8170 | 6468 | 1702 | 0.79167686658506731
3 | desktop | speculation-rules | 6454 | 3253 | 3201 | 0.5040285094515029
4 | desktop | performant-translations | 4921 | 2799 | 2122 | 0.56878683194472668
5 | desktop | auto-sizes | 3644 | 3223 | 421 | 0.88446761800219542
6 | desktop | embed-optimizer | 3052 | 2041 | 1011 | 0.66874180865006549
7 | desktop | optimization-detective | 1129 | 1049 | 80 | 0.929140832595217
8 | desktop | image-prioritizer | 1041 | 995 | 46 | 0.95581171950048027
9 | mobile | webp-uploads | 12703 | 10427 | 2276 | 0.82082972526174924
10 | mobile | dominant-color-images | 9636 | 7622 | 2014 | 0.79099211290992111
11 | mobile | speculation-rules | 7238 | 3870 | 3368 | 0.53467808786957727
12 | mobile | performant-translations | 6161 | 3445 | 2716 | 0.55916247362441163
13 | mobile | auto-sizes | 4422 | 3932 | 490 | 0.88919041157847123
14 | mobile | embed-optimizer | 3715 | 2503 | 1212 | 0.67375504710632572
15 | mobile | optimization-detective | 1384 | 1278 | 106 | 0.92341040462427748
16 | mobile | image-prioritizer | 1270 | 1213 | 57 | 0.95511811023622051