### PR TITLE
Implement query to get the usage of different WordPress template types on the home page

### DIFF
--- a/sql/2024/08/home-page-template-types-popularity.sql
+++ b/sql/2024/08/home-page-template-types-popularity.sql
@@ -1,0 +1,73 @@
+# HTTP Archive query to get the usage of different WordPress template types on the home page.
+#
+# WPP Research, Copyright 2024 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# See https://github.com/GoogleChromeLabs/wpp-research/pull/150
+
+DECLARE DATE_TO_QUERY DATE DEFAULT '2024-07-01';
+
+CREATE TEMPORARY FUNCTION IS_CMS(technologies ARRAY<STRUCT<technology STRING, categories ARRAY<STRING>, info ARRAY<STRING>>>, cms STRING, version STRING) RETURNS BOOL AS (
+  EXISTS(
+    SELECT * FROM UNNEST(technologies) AS technology, UNNEST(technology.info) AS info
+    WHERE technology.technology = cms
+    AND (
+      version = ""
+      OR ENDS_WITH(version, ".x") AND (STARTS_WITH(info, RTRIM(version, "x")) OR info = RTRIM(version, ".x"))
+      OR info = version
+    )
+  )
+);
+
+CREATE TEMPORARY FUNCTION GET_CONTENT_TYPE(custom_metrics STRING) RETURNS STRUCT<template STRING, postType STRING, taxonomy STRING> AS (
+  STRUCT(
+    CAST(JSON_EXTRACT_SCALAR(custom_metrics, "$.cms.wordpress.content_type.template") AS STRING) AS template,
+    CAST(JSON_EXTRACT_SCALAR(custom_metrics, "$.cms.wordpress.content_type.post_type") AS STRING) AS postType,
+    CAST(JSON_EXTRACT_SCALAR(custom_metrics, "$.cms.wordpress.content_type.taxonomy") AS STRING) AS taxonomy
+  )
+);
+
+WITH contentTypes AS (
+  SELECT
+    date,
+    "WordPress" AS cms,
+    IF(client = "mobile", "phone", "desktop") AS device,
+    page AS url,
+    GET_CONTENT_TYPE(custom_metrics) AS contentType
+  FROM
+    `httparchive.all.pages`
+  WHERE
+    date = DATE_TO_QUERY
+    AND IS_CMS(technologies, "WordPress", "")
+    AND is_root_page = TRUE
+)
+
+SELECT
+  date,
+  cms,
+  device,
+  contentType.template AS contentTypeSummary,
+  COUNT(url) AS urls
+FROM
+  contentTypes
+GROUP BY
+  date,
+  cms,
+  device,
+  contentType.template
+ORDER BY
+  date ASC,
+  cms ASC,
+  device ASC,
+  urls DESC

--- a/sql/README.md
+++ b/sql/README.md
@@ -23,6 +23,7 @@ For additional considerations for writing BigQuery queries against HTTP Archive,
 ### 2024/08
 
 * [Active install counts for Performance Lab plugins (with or without the Performance Lab plugin)](./2024/08/performance-lab-plugins-adoption.sql)
+* [Usage of different WordPress template types on the home page](./2024/08/home-page-template-types-popularity.sql)
 
 ### 2024/04
 


### PR DESCRIPTION
In recent years, it has been brought up several times to change the WordPress default of showing a blog on the home page by default to showing a static front page instead. This query looks at how common each variant is across the WordPress home pages indexed by HTTP Archive.

This is based on the [detection implemented in the `httparchive/custom-metrics` repository](https://github.com/HTTPArchive/custom-metrics/blob/main/dist/cms.js#L85), which relies on the WordPress-generated body classes.

## Query results

Row | date | cms | device | contentTypeSummary | urls
-- | -- | -- | -- | -- | --
1 | 2024-07-01 | WordPress | desktop | home-page | 3449866
2 | 2024-07-01 | WordPress | desktop | home-blog | 531538
3 | 2024-07-01 | WordPress | desktop | unknown | 380071
4 | 2024-07-01 | WordPress | desktop | null | 15173
5 | 2024-07-01 | WordPress | desktop | blog | 15099
6 | 2024-07-01 | WordPress | desktop | archive | 1429
7 | 2024-07-01 | WordPress | desktop | singular | 493
8 | 2024-07-01 | WordPress | phone | home-page | 4415076
9 | 2024-07-01 | WordPress | phone | home-blog | 742331
10 | 2024-07-01 | WordPress | phone | unknown | 470458
11 | 2024-07-01 | WordPress | phone | blog | 21126
12 | 2024-07-01 | WordPress | phone | null | 12516
13 | 2024-07-01 | WordPress | phone | archive | 2688
14 | 2024-07-01 | WordPress | phone | singular | 637

## Summary

* More than 78% of home pages use a static front page (matches in both mobile and desktop detection). This supports the proposal that it is not a good default to use a blog.
* There are some edge-cases where some home pages are a `blog` (i.e. not determined as the _home_ blog), an `archive`, or `singular` content. Those are consistently far lower than 1% though, so it's not too relevant for the data. Possibly it happens because HTTP Archive considers some pages as root pages that are technically not the home page of the respective _WordPress_ site.