### PR TITLE
Fix appending `rnd` query parameter to URLs in benchmark-server-timing

### DIFF
--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -132,7 +132,6 @@ function benchmarkURL( params ) {
 	const metrics = {};
 	const responseTimes = [];
 	let completeRequests = 0;
-	let requestNum = 0;
 
 	const onHeaders = ( { headers } ) => {
 		const responseMetrics = getServerTimingMetricsFromHeaders( headers );
@@ -154,9 +153,11 @@ function benchmarkURL( params ) {
 		requests: [
 			{
 				setupRequest( req ) {
+					const url = new URL( req.path, 'http://localhost' ); // The base doesn't matter since we're only manipulating the path.
+					url.searchParams.set( 'rnd', String( Math.random() ) );
 					return {
 						...req,
-						path: `${ req.path }?rnd=${ requestNum++ }`,
+						path: url.pathname + url.search,
 					};
 				},
 			},


### PR DESCRIPTION
When running `benchmark-server-timing` on a URL I was seeing the expected results:

```
npm run research -- benchmark-server-timing -u 'http://localhost:10053/'

> research
> ./cli/run.mjs benchmark-server-timing -u http://localhost:10053/

╔════════════════════════════════════╤═════════════════════════╗
║ URL                                │ http://localhost:10053/ ║
╟────────────────────────────────────┼─────────────────────────╢
║ Success Rate                       │ 100%                    ║
╟────────────────────────────────────┼─────────────────────────╢
║ Response Time (median)             │ 45.71                   ║
╟────────────────────────────────────┼─────────────────────────╢
║ wp-before-template (median)        │ 19.61                   ║
╟────────────────────────────────────┼─────────────────────────╢
║ wp-template (median)               │ 22.75                   ║
╟────────────────────────────────────┼─────────────────────────╢
║ wp-optimization-detective (median) │ 3.41                    ║
╟────────────────────────────────────┼─────────────────────────╢
║ wp-total (median)                  │ 42.37                   ║
╚════════════════════════════════════╧═════════════════════════╝
```

However, when I tried adding a query parameter then I found the Success Rate to be 0%:

```
npm run research -- benchmark-server-timing -u 'http://localhost:10053/?optimization_detective_disabled=1'

> research
> ./cli/run.mjs benchmark-server-timing -u http://localhost:10053/?optimization_detective_disabled=1

╔════════════════════════╤═══════════════════════════════════════════════════════════╗
║ URL                    │ http://localhost:10053/?optimization_detective_disabled=1 ║
╟────────────────────────┼───────────────────────────────────────────────────────────╢
║ Success Rate           │ 0%                                                        ║
╟────────────────────────┼───────────────────────────────────────────────────────────╢
║ Response Time (median) │ 22.75                                                     ║
╟────────────────────────┼───────────────────────────────────────────────────────────╢
║ wp-total (median)      │ 19.66                                                     ║
╚════════════════════════╧═══════════════════════════════════════════════════════════╝
```

I thought this was a problem in Optimization Detective but no, it happens when there is any query param:

```
$ npm run research -- benchmark-server-timing -u 'http://localhost:10053/?foo=bar'

> research
> ./cli/run.mjs benchmark-server-timing -u http://localhost:10053/?foo=bar

╔════════════════════════╤═════════════════════════════════╗
║ URL                    │ http://localhost:10053/?foo=bar ║
╟────────────────────────┼─────────────────────────────────╢
║ Success Rate           │ 0%                              ║
╟────────────────────────┼─────────────────────────────────╢
║ Response Time (median) │ 30.43                           ║
╟────────────────────────┼─────────────────────────────────╢
║ wp-total (median)      │ 24.98                           ║
╚════════════════════════╧═════════════════════════════════╝
```

The problem is that the `rnd` query parameter is being added by appending `?rnd=...` to the URL without accounting for whether there are existing query parameters in the URL. This fixes that problem, while also using `Math.random()` rather than an auto-incremented number. These changes had previously been done for `benchmark-web-vitals` in #60.

With the changes in this PR:

```
$ npm run research -- benchmark-server-timing -u 'http://localhost:10053/?optimization_detective_disabled=1'

> research
> ./cli/run.mjs benchmark-server-timing -u http://localhost:10053/?optimization_detective_disabled=1

╔═════════════════════════════╤═══════════════════════════════════════════════════════════╗
║ URL                         │ http://localhost:10053/?optimization_detective_disabled=1 ║
╟─────────────────────────────┼───────────────────────────────────────────────────────────╢
║ Success Rate                │ 100%                                                      ║
╟─────────────────────────────┼───────────────────────────────────────────────────────────╢
║ Response Time (median)      │ 48.76                                                     ║
╟─────────────────────────────┼───────────────────────────────────────────────────────────╢
║ wp-before-template (median) │ 25.4                                                      ║
╟─────────────────────────────┼───────────────────────────────────────────────────────────╢
║ wp-template (median)        │ 16.63                                                     ║
╟─────────────────────────────┼───────────────────────────────────────────────────────────╢
║ wp-total (median)           │ 42.03                                                     ║
╚═════════════════════════════╧═══════════════════════════════════════════════════════════╝
```

And:

```
$ npm run research -- benchmark-server-timing -u 'http://localhost:10053/' -n 100

> research
> ./cli/run.mjs benchmark-server-timing -u http://localhost:10053/ -n 100

╔════════════════════════════════════╤═════════════════════════╗
║ URL                                │ http://localhost:10053/ ║
╟────────────────────────────────────┼─────────────────────────╢
║ Success Rate                       │ 100%                    ║
╟────────────────────────────────────┼─────────────────────────╢
║ Response Time (median)             │ 32.13                   ║
╟────────────────────────────────────┼─────────────────────────╢
║ wp-before-template (median)        │ 12.12                   ║
╟────────────────────────────────────┼─────────────────────────╢
║ wp-template (median)               │ 18.32                   ║
╟────────────────────────────────────┼─────────────────────────╢
║ wp-optimization-detective (median) │ 3.17                    ║
╟────────────────────────────────────┼─────────────────────────╢
║ wp-total (median)                  │ 31.05                   ║
╚════════════════════════════════════╧═════════════════════════╝
```

And:

```
$ npm run research -- benchmark-server-timing --file=preload-bgimage-urls.txt --number 100

> research
> ./cli/run.mjs benchmark-server-timing --file=preload-bgimage-urls.txt --number 100

Benchmarking URL http://localhost:10053/?optimization_detective_disabled=1...Success.
Benchmarking URL http://localhost:10053/...Success.
╔════════════════════════════════════╤═══════════════════════════════════════════════════════════╤═════════════════════════╗
║ URL                                │ http://localhost:10053/?optimization_detective_disabled=1 │ http://localhost:10053/ ║
╟────────────────────────────────────┼───────────────────────────────────────────────────────────┼─────────────────────────╢
║ Success Rate                       │ 100%                                                      │ 100%                    ║
╟────────────────────────────────────┼───────────────────────────────────────────────────────────┼─────────────────────────╢
║ Response Time (median)             │ 29.25                                                     │ 33.57                   ║
╟────────────────────────────────────┼───────────────────────────────────────────────────────────┼─────────────────────────╢
║ wp-before-template (median)        │ 12.62                                                     │ 12.88                   ║
╟────────────────────────────────────┼───────────────────────────────────────────────────────────┼─────────────────────────╢
║ wp-template (median)               │ 15.52                                                     │ 19.09                   ║
╟────────────────────────────────────┼───────────────────────────────────────────────────────────┼─────────────────────────╢
║ wp-total (median)                  │ 28.02                                                     │ 32.38                   ║
╟────────────────────────────────────┼───────────────────────────────────────────────────────────┼─────────────────────────╢
║ wp-optimization-detective (median) │                                                           │ 3.24                    ║
╚════════════════════════════════════╧═══════════════════════════════════════════════════════════╧═════════════════════════╝
```