### PR TITLE
Add device emulation to `benchmark-web-vitals`

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -162,7 +162,8 @@ Loads the provided URLs in a headless browser several times to measure median We
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 * `--throttle-cpu` (`-t`): Enable CPU throttling to emulate slow CPUs.
 * `--network-conditions` (`-c`): Enable emulation of network conditions (may be either "Slow 3G" or "Fast 3G").
-* `--window-viewport` (`-w`): Specify the viewport window size, like "mobile" (an alias for "412x823") or "desktop" (an alias for "1350x940"). Defaults to "960x700".
+* `--emulate-device` (`-e`): Emulate a specific device, like "Moto G4" or "iPad". See list of [known devices](https://pptr.dev/api/puppeteer.knowndevices). 
+* `--window-viewport` (`-w`): Specify the viewport window size, like "mobile" (an alias for "412x823") or "desktop" (an alias for "1350x940"). Defaults to "960x700" if no device is being emulated.
 
 #### Examples
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -19,7 +19,11 @@
 /**
  * External dependencies
  */
-import puppeteer, { Browser, PredefinedNetworkConditions, KnownDevices } from 'puppeteer';
+import puppeteer, {
+	Browser,
+	PredefinedNetworkConditions,
+	KnownDevices,
+} from 'puppeteer';
 import round from 'lodash-es/round.js';
 
 /* eslint-disable jsdoc/valid-types */
@@ -103,7 +107,8 @@ export const options = [
 	},
 	{
 		argname: '-e, --emulate-device <device>',
-		description: 'Enable a specific device by name, for example "Moto G4" or "iPad"',
+		description:
+			'Enable a specific device by name, for example "Moto G4" or "iPad"',
 	},
 	{
 		argname: '-w, --window-viewport <dimensions>',
@@ -171,7 +176,9 @@ function getParamsFromOptions( opt ) {
 		cpuThrottleFactor: null,
 		networkConditions: null,
 		emulateDevice: null,
-		windowViewport: ! opt.emulateDevice ? { width: 960, height: 700 } : null, // Viewport similar to @wordpress/e2e-test-utils 'large' configuration.
+		windowViewport: ! opt.emulateDevice
+			? { width: 960, height: 700 }
+			: null, // Viewport similar to @wordpress/e2e-test-utils 'large' configuration.
 	};
 
 	if ( isNaN( params.amount ) ) {
@@ -473,8 +480,10 @@ async function benchmarkURL(
 		}
 		if ( params.windowViewport ) {
 			await page.setViewport( {
-				...( params.emulateDevice ? params.emulateDevice.viewport : {} ),
-				...params.windowViewport
+				...( params.emulateDevice
+					? params.emulateDevice.viewport
+					: {} ),
+				...params.windowViewport,
 			} );
 		}
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -24,7 +24,7 @@ import round from 'lodash-es/round.js';
 
 /* eslint-disable jsdoc/valid-types */
 /** @typedef {import("puppeteer").NetworkConditions} NetworkConditions */
-/** @typedef {keyof typeof import("puppeteer").networkConditions} NetworkConditionName */
+/** @typedef {keyof typeof PredefinedNetworkConditions} NetworkConditionName */
 /* eslint-enable jsdoc/valid-types */
 /** @typedef {{width: number, height: number}} ViewportDimensions */
 
@@ -338,7 +338,7 @@ export async function handler( opt ) {
 	const params = getParamsFromOptions( opt );
 	const results = [];
 
-	const browser = await puppeteer.launch( { headless: 'new' } );
+	const browser = await puppeteer.launch( { headless: true } );
 
 	const metricsDefinition = getMetricsDefinition( params.metrics );
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -468,11 +468,11 @@ async function benchmarkURL(
 			await page.emulateNetworkConditions( params.networkConditions );
 		}
 
-		if ( params.windowViewport ) {
-			await page.setViewport( params.windowViewport );
-		}
 		if ( params.emulateDevice ) {
 			await page.emulate( params.emulateDevice );
+		}
+		if ( params.windowViewport ) {
+			await page.setViewport( params.windowViewport );
 		}
 
 		// Load the page.

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -472,7 +472,10 @@ async function benchmarkURL(
 			await page.emulate( params.emulateDevice );
 		}
 		if ( params.windowViewport ) {
-			await page.setViewport( params.windowViewport );
+			await page.setViewport( {
+				...( params.emulateDevice ? params.emulateDevice.viewport : {} ),
+				...params.windowViewport
+			} );
 		}
 
 		// Load the page.


### PR DESCRIPTION
This is a follow-up to #164.

Being able to specify the window dimensions alone is not always sufficient to test a page. In particular, there is also the device scale factor which is often higher on mobile devices. More importantly, if the user agent is not indicating a mobile device then a site may return a page formatted for desktop. This PR introduces a `--emulate-device` (`-e`) parameter to specify one of the [known devices](https://pptr.dev/api/puppeteer.knowndevices) in Puppeteer. The `--window-viewport` arg may still be supplied, and it will override the `width` and `height` of the emulated device. If no device is being emulated, then the default viewport remains 960x700.