### PR TITLE
Update existing queries to use latest `httparchive.crawl.*` dataset

### DIFF
--- a/sql/2022/11/performance-lab-version-distribution.sql
+++ b/sql/2022/11/performance-lab-version-distribution.sql
@@ -15,26 +15,18 @@
 # limitations under the License.
 
 SELECT
-  info as version,
-  COUNT(DISTINCT url) AS sites,
-  COUNT(DISTINCT url) / total AS pct_sites
-FROM
-  `httparchive.technologies.2022_10_01_*`
-JOIN (
-  SELECT
-    app,
-    COUNT(DISTINCT url) AS total
-  FROM
-    `httparchive.technologies.2022_10_01_*`
-  GROUP BY
-    app
-)
-USING
-  (app)
-WHERE
-  app = 'Performance Lab'
-GROUP BY
   version,
-  total
+  COUNT(DISTINCT page) AS sites,
+  COUNT(DISTINCT page) / SUM(COUNT(DISTINCT page)) OVER () AS pct_sites
+FROM
+  `httparchive.crawl.pages`,
+  UNNEST(technologies) AS technology,
+  UNNEST(technology.info) AS version
+WHERE
+  date = '2022-10-01'
+  AND is_root_page
+  AND technology.technology = 'Performance Lab'
+GROUP BY
+  version
 ORDER BY
   sites DESC

--- a/sql/2022/12/usage-of-core-themes-with-jquery.sql
+++ b/sql/2022/12/usage-of-core-themes-with-jquery.sql
@@ -16,27 +16,33 @@
 
 # See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/13
 SELECT
-  _TABLE_SUFFIX AS client,
-  app,
-  COUNT(DISTINCT url) AS sites,
-  COUNT(DISTINCT url) / total AS pct_sites
+  client,
+  technology.technology AS app,
+  COUNT(DISTINCT page) AS sites,
+  COUNT(DISTINCT page) / total AS pct_sites
 FROM
-  `httparchive.technologies.2022_10_01_*`
+  `httparchive.crawl.pages`,
+  UNNEST(technologies) AS technology
 JOIN (
   SELECT
-    _TABLE_SUFFIX,
-    COUNT(DISTINCT url) AS total
+    client,
+    COUNT(DISTINCT page) AS total
   FROM
-    `httparchive.technologies.2022_10_01_*`
+    `httparchive.crawl.pages`,
+    UNNEST(technologies) AS technology
   WHERE
-    app = "WordPress"
+    date = '2022-10-01'
+    AND is_root_page
+    AND technology.technology = "WordPress"
   GROUP BY
-    _TABLE_SUFFIX
+    client
 )
 USING
-  (_TABLE_SUFFIX)
+  (client)
 WHERE
-  app IN (
+  date = '2022-10-01'
+  AND is_root_page
+  AND technology.technology IN (
     "Twenty Eleven",
     "Twenty Twelve",
     "Twenty Thirteen",

--- a/sql/2023/01/alloptions-query-time-distribution.sql
+++ b/sql/2023/01/alloptions-query-time-distribution.sql
@@ -27,10 +27,10 @@ WITH relevantServerTimings AS (
   SELECT
     client,
     url,
-    EXTRACT_SERVER_TIMING_METRIC(httparchive.all.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-load-alloptions-query') AS alloptions_query_time,
-    EXTRACT_SERVER_TIMING_METRIC(httparchive.all.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-before-template') AS before_template_time
+    EXTRACT_SERVER_TIMING_METRIC(httparchive.fn.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-load-alloptions-query') AS alloptions_query_time,
+    EXTRACT_SERVER_TIMING_METRIC(httparchive.fn.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-before-template') AS before_template_time
   FROM
-    `httparchive.all.requests`,
+    `httparchive.crawl.requests`,
     UNNEST(response_headers) AS response_header
   WHERE
     date = '2023-01-01'

--- a/sql/2023/01/cwvs-by-wordpress-version.sql
+++ b/sql/2023/01/cwvs-by-wordpress-version.sql
@@ -43,7 +43,7 @@ SELECT
   AVG( pct_eligible_origins_with_good_cwv ) AS pct_eligible_origins_with_good_cwv
 FROM (
   SELECT
-    REGEXP_EXTRACT(info, '(\\d.\\d).*') AS major_version,
+    REGEXP_EXTRACT(version, '(\\d.\\d).*') AS major_version,
     client,
     COUNT(DISTINCT url) AS origins,
     COUNT(DISTINCT IF (good_fid, url, NULL)) AS origins_with_good_fid,
@@ -79,18 +79,23 @@ FROM (
         'phone') )
   JOIN (
     SELECT
-      DISTINCT CAST('2022-10-01' AS DATE) AS date,
+      date,
       category,
-      app,
-      info,
-      _TABLE_SUFFIX AS client,
-      url
+      technology.technology AS app,
+      version,
+      client,
+      page AS url
     FROM
-      `httparchive.technologies.2022_10_01_*`
+      `httparchive.crawl.pages`,
+      UNNEST(technologies) AS technology,
+      UNNEST(technology.categories) AS category,
+      UNNEST(technology.info) AS version
     WHERE
-      app = 'WordPress'
+      date = '2022-10-01'
+      AND is_root_page
+      AND technology.technology = 'WordPress'
       AND category = 'CMS'
-      AND info != '' )
+      AND version != '' )
   USING
     (date,
       url,
@@ -99,7 +104,7 @@ FROM (
     date,
     major_version,
     app,
-    info,
+    version,
     client )
 WHERE
   origins > 100

--- a/sql/2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql
+++ b/sql/2023/01/lcp-image-without-fetchpriority-high-opportunity-more-efficient.sql
@@ -16,11 +16,11 @@
 
 # See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/27
 CREATE TEMP FUNCTION
-  getFetchPriorityAttr(attributes STRING)
+  getFetchPriorityAttr(performance JSON)
   RETURNS STRING
   LANGUAGE js AS '''
 try {
-  const data = JSON.parse(attributes);
+  const data = performance.lcp_elem_stats.attributes;
   const fetchpriorityAttr = data.find(attr => attr["name"] === "fetchpriority")
   return fetchpriorityAttr.value;
 } catch (e) {
@@ -30,16 +30,22 @@ try {
 
 WITH
   lcp_stats AS (
-  SELECT
-    _TABLE_SUFFIX AS client,
-    url,
-    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.nodeName') AS nodeName,
-    JSON_EXTRACT_SCALAR(payload, '$._performance.lcp_elem_stats.url') AS elementUrl,
-    JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes') AS attributes,
-    JSON_EXTRACT(payload, '$._detected_apps.WordPress') AS wpVersion,
-    getFetchPriorityAttr(JSON_EXTRACT(payload, '$._performance.lcp_elem_stats.attributes')) AS fetchpriority,
+  # The `DISTINCT` is necessary to strip duplicate entries due to `UNNEST(technology.info)` which will result in 2 entries for each actual record.
+  SELECT DISTINCT
+    client,
+    page AS url,
+    JSON_VALUE(custom_metrics.performance.lcp_elem_stats.nodeName) AS nodeName,
+    JSON_VALUE(custom_metrics.performance.lcp_elem_stats.url) AS elementUrl,
+    wpVersion,
+    getFetchPriorityAttr(custom_metrics.performance) AS fetchpriority,
   FROM
-    `httparchive.pages.2022_10_01_*`
+    `httparchive.crawl.pages`,
+    UNNEST(technologies) AS technology,
+    UNNEST(technology.info) AS wpVersion
+  WHERE
+    date = '2022-10-01'
+    AND is_root_page
+    AND technology.technology = 'WordPress'
 )
 
 SELECT

--- a/sql/2023/01/sites-with-deferred-scripts.sql
+++ b/sql/2023/01/sites-with-deferred-scripts.sql
@@ -16,14 +16,17 @@
 
 # See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/29
 SELECT
-  _TABLE_SUFFIX AS client,
-  COUNTIF(CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.defer') AS INT64) > 0) AS with_deferred_scripts,
-  COUNTIF(CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.src') AS INT64) > 0) AS with_any_external_scripts,
+  client,
+  COUNTIF(CAST(JSON_VALUE(custom_metrics.javascript.script_tags.defer) AS INT64) > 0) AS with_deferred_scripts,
+  COUNTIF(CAST(JSON_VALUE(custom_metrics.javascript.script_tags.src) AS INT64) > 0) AS with_any_external_scripts,
   COUNT(0) AS total_wp_sites,
-  COUNTIF(CAST(JSON_EXTRACT(JSON_EXTRACT_SCALAR(payload, '$._javascript'), '$.script_tags.defer') AS INT64) > 0) / COUNT(0) AS defer_pct,
+  COUNTIF(CAST(JSON_VALUE(custom_metrics.javascript.script_tags.defer) AS INT64) > 0) / COUNT(0) AS defer_pct,
 FROM
-  `httparchive.pages.2022_10_01_*`
+  `httparchive.crawl.pages`,
+  UNNEST(technologies) AS technology
 WHERE
-  JSON_EXTRACT(payload, '$._detected_apps.WordPress') IS NOT NULL
+  date = '2022-10-01'
+  AND is_root_page
+  AND technology.technology = 'WordPress'
 GROUP BY
   client

--- a/sql/2023/01/sites-with-slow-alloptions-queries.sql
+++ b/sql/2023/01/sites-with-slow-alloptions-queries.sql
@@ -27,10 +27,10 @@ WITH relevantServerTimings AS (
   SELECT
     client,
     url,
-    EXTRACT_SERVER_TIMING_METRIC(httparchive.all.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-load-alloptions-query') AS alloptions_query_time,
-    EXTRACT_SERVER_TIMING_METRIC(httparchive.all.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-before-template') AS before_template_time
+    EXTRACT_SERVER_TIMING_METRIC(httparchive.fn.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-load-alloptions-query') AS alloptions_query_time,
+    EXTRACT_SERVER_TIMING_METRIC(httparchive.fn.PARSE_SERVER_TIMING_HEADER(response_header.value), 'wp-before-template') AS before_template_time
   FROM
-    `httparchive.all.requests`,
+    `httparchive.crawl.requests`,
     UNNEST(response_headers) AS response_header
   WHERE
     date = '2023-01-01'

--- a/sql/2023/01/webp-adoption-by-wordpress-version.sql
+++ b/sql/2023/01/webp-adoption-by-wordpress-version.sql
@@ -31,33 +31,30 @@ FROM (
       COUNT(0) AS pages,
       COUNTIF(has_webp) / COUNT(0) AS pct_webp
     FROM (
-      SELECT
-        DISTINCT url,
-        REGEXP_EXTRACT(info, r'(\d\.\d+)') AS version
+      SELECT DISTINCT
+        page AS url,
+        REGEXP_EXTRACT(version, r'(\d\.\d+)') AS version
       FROM
-        `httparchive.technologies.2022_10_01_mobile`
+        `httparchive.crawl.pages`,
+        UNNEST(technologies) AS technology,
+        UNNEST(info) AS version
       WHERE
-        app = 'WordPress' )
+        date = '2022-10-01'
+        AND client = 'mobile'
+        AND is_root_page
+        AND technology.technology = 'WordPress' )
     JOIN (
       SELECT
-        url,
-        has_webp
-      FROM (
-        SELECT
-          pageid,
-          COUNTIF(ext = 'webp') > 0 AS has_webp
-        FROM
-          `httparchive.summary_requests.2022_10_01_mobile`
-        GROUP BY
-          pageid )
-      JOIN (
-        SELECT
-          pageid,
-          url
-        FROM
-          `httparchive.summary_pages.2022_10_01_mobile` )
-      USING
-        (pageid) )
+        page AS url,
+        COUNTIF(JSON_VALUE(summary.ext) = 'webp') > 0 AS has_webp
+      FROM
+        `httparchive.crawl.requests`
+      WHERE
+        date = '2022-10-01'
+        AND client = 'mobile'
+        AND is_root_page
+      GROUP BY
+        page )
     USING
       (url)
     WHERE
@@ -79,33 +76,30 @@ JOIN (
       COUNT(0) AS pages,
       COUNTIF(has_webp) / COUNT(0) AS pct_webp
     FROM (
-      SELECT
-        DISTINCT url,
-        REGEXP_EXTRACT(info, r'(\d\.\d+)') AS version
+      SELECT DISTINCT
+        page AS url,
+        REGEXP_EXTRACT(version, r'(\d\.\d+)') AS version
       FROM
-        `httparchive.technologies.2022_10_01_desktop`
+        `httparchive.crawl.pages`,
+        UNNEST(technologies) AS technology,
+        UNNEST(info) AS version
       WHERE
-        app = 'WordPress' )
+        date = '2022-10-01'
+        AND client = 'desktop'
+        AND is_root_page
+        AND technology.technology = 'WordPress' )
     JOIN (
       SELECT
-        url,
-        has_webp
-      FROM (
-        SELECT
-          pageid,
-          COUNTIF(ext = 'webp') > 0 AS has_webp
-        FROM
-          `httparchive.summary_requests.2022_10_01_desktop`
-        GROUP BY
-          pageid )
-      JOIN (
-        SELECT
-          pageid,
-          url
-        FROM
-          `httparchive.summary_pages.2022_10_01_desktop` )
-      USING
-        (pageid) )
+        page AS url,
+        COUNTIF(JSON_VALUE(summary.ext) = 'webp') > 0 AS has_webp
+      FROM
+        `httparchive.crawl.requests`
+      WHERE
+        date = '2022-10-01'
+        AND client = 'desktop'
+        AND is_root_page
+      GROUP BY
+        page )
     USING
       (url)
     WHERE

--- a/sql/2023/03/critical-css-opportunity-custom-metrics.sql
+++ b/sql/2023/03/critical-css-opportunity-custom-metrics.sql
@@ -23,16 +23,19 @@ SELECT
   (total_wp_sites - sites_with_critical_css) / total_wp_sites AS opportunity
 FROM (
   SELECT
-    pages._TABLE_SUFFIX AS client,
-    COUNT(pages.url) AS total_wp_sites,
+    client,
+    COUNT(page) AS total_wp_sites,
     COUNTIF(
-      CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._css'), '$.externalCssInHead') AS INT64) = 0
-      AND CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._css'), '$.inlineCssInHead') AS INT64) > 0
-      AND CAST(JSON_EXTRACT_SCALAR(JSON_EXTRACT_SCALAR(payload, '$._css'), '$.externalCssInBody') AS INT64) > 0
+      CAST(JSON_VALUE(custom_metrics.other.css.externalCssInHead) AS INT64) = 0
+      AND CAST(JSON_VALUE(custom_metrics.other.css.inlineCssInHead) AS INT64) > 0
+      AND CAST(JSON_VALUE(custom_metrics.other.css.externalCssInBody) AS INT64) > 0
     ) AS sites_with_critical_css
   FROM
-    `httparchive.pages.2022_03_01_*` AS pages
+    `httparchive.crawl.pages`,
+    UNNEST(technologies) AS technology
   WHERE
-    JSON_EXTRACT(pages.payload, '$._detected_apps.WordPress') IS NOT NULL
+    date = '2023-03-01'
+    AND is_root_page
+    AND technology.technology = 'WordPress'
   GROUP BY
-    pages._TABLE_SUFFIX )
+    client )

--- a/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
+++ b/sql/2023/08/blocking-head-scripts-count-by-plugin.sql
@@ -16,7 +16,7 @@
 
 
 # Based on query here: https://github.com/GoogleChromeLabs/wpp-research/pull/63
-CREATE TEMP FUNCTION GET_BLOCKING_HEAD_SOURCES(custom_metrics STRING)
+CREATE TEMP FUNCTION GET_BLOCKING_HEAD_SOURCES(cms JSON)
 RETURNS ARRAY<STRING>
 LANGUAGE js
 AS '''
@@ -40,15 +40,14 @@ function getSource(src) {
 /**
  * Get script sources for scripts in the head which are blocking (not async nor defer).
  *
- * @param {object} data
- * @param {object} data.cms
- * @param {object} data.cms.wordpress
- * @param {Array<{src: string, intended_strategy: string, async: boolean, defer: boolean, in_footer: boolean}>} data.cms.wordpress.scripts
+ * @param {object} cms
+ * @param {object} cms.wordpress
+ * @param {Array<{src: string, intended_strategy: string, async: boolean, defer: boolean, in_footer: boolean}>} cms.wordpress.scripts
  * @return {Array} Sources.
  */
-function getBlockingHeadScriptSources(data) {
+function getBlockingHeadScriptSources(cms) {
   const sources = [];
-  for ( const script of data.cms.wordpress.scripts ) {
+  for ( const script of cms.wordpress.scripts ) {
 
     const source = getSource(script.src);
     if (!source) {
@@ -65,8 +64,7 @@ function getBlockingHeadScriptSources(data) {
 
 const sources = [];
 try {
-  const data = JSON.parse(custom_metrics);
-  sources.push(...getBlockingHeadScriptSources(data));
+  sources.push(...getBlockingHeadScriptSources(cms));
 } catch (e) {}
 return sources;
 ''';
@@ -74,9 +72,9 @@ return sources;
 WITH
   all_sources AS (
     SELECT
-      GET_BLOCKING_HEAD_SOURCES(custom_metrics) AS sources,
+      GET_BLOCKING_HEAD_SOURCES(custom_metrics.cms) AS sources,
     FROM
-      `httparchive.all.pages`,
+      `httparchive.crawl.pages`,
       UNNEST(technologies) AS technology
     WHERE
       date = CAST('2023-07-01' AS DATE)

--- a/sql/2023/10/bfcache-failure-reasons.sql
+++ b/sql/2023/10/bfcache-failure-reasons.sql
@@ -16,16 +16,15 @@
 
 # See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/75
 
-CREATE TEMP FUNCTION getItemReasons(items STRING) RETURNS ARRAY<STRING> LANGUAGE js AS
+CREATE TEMP FUNCTION getItemReasons(items JSON) RETURNS ARRAY<STRING> LANGUAGE js AS
 # language=javascript
 '''
   try {
     if ( ! items ) {
       return [];
     }
-    const parsedItems = JSON.parse(items);
     const reasons = [];
-    for ( const item of parsedItems ) {
+    for ( const item of items ) {
       reasons.push( item.reason );
     }
     return reasons;
@@ -35,13 +34,12 @@ CREATE TEMP FUNCTION getItemReasons(items STRING) RETURNS ARRAY<STRING> LANGUAGE
 ''';
 
 WITH
-
    wordPressPages AS (
     SELECT
       page as url,
-      getItemReasons( JSON_EXTRACT(lighthouse, '$.audits.bf-cache.details.items')) AS reasons
+      getItemReasons(lighthouse.audits['bf-cache'].details.items) AS reasons
     FROM
-      `httparchive.all.pages`,
+      `httparchive.crawl.pages`,
       UNNEST(technologies) AS t
     WHERE
       date = '2023-08-01' AND

--- a/sql/2023/10/bfcache-score-counts.sql
+++ b/sql/2023/10/bfcache-score-counts.sql
@@ -21,9 +21,9 @@ WITH
   wordPressPages AS (
     SELECT
       page as url,
-      JSON_EXTRACT(lighthouse, '$.audits.bf-cache.score') AS bfCacheScore
+      JSON_VALUE(lighthouse.audits['bf-cache'].score) AS bfCacheScore
     FROM
-      `httparchive.all.pages`,
+      `httparchive.crawl.pages`,
       UNNEST(technologies) AS t
     WHERE
       date = '2023-08-01' AND

--- a/sql/2023/10/page-content-types.sql
+++ b/sql/2023/10/page-content-types.sql
@@ -20,7 +20,7 @@ WITH pages AS (
     client,
     page AS url
   FROM
-    `httparchive.all.pages`,
+    `httparchive.crawl.pages`,
     UNNEST(technologies) AS t
   WHERE
     date = '2023-08-01' AND
@@ -35,7 +35,7 @@ requests AS (
     url,
     REGEXP_REPLACE( resp_headers.value, ' *;.*$', '' ) AS content_type
   FROM
-    `httparchive.all.requests`,
+    `httparchive.crawl.requests`,
     UNNEST(response_headers) as resp_headers
   WHERE
     date = "2023-08-01" AND

--- a/sql/2024/01/embed-blocks-on-root-and-non-root-pages.sql
+++ b/sql/2024/01/embed-blocks-on-root-and-non-root-pages.sql
@@ -18,11 +18,11 @@
 
 SELECT
   is_root_page,
-  JSON_EXTRACT(custom_metrics, '$.cms.wordpress.has_embed_block') AS has_embed_block,
+  CAST(JSON_VALUE(custom_metrics.cms.wordpress.has_embed_block) AS BOOL) AS has_embed_block,
   COUNT(*) AS page_count,
   ROUND(100.0 * COUNT(*) / SUM(COUNT(*)) OVER (), 1) AS percentage_of_total
 FROM
-  `httparchive.all.pages`,
+  `httparchive.crawl.pages`,
   UNNEST(technologies) AS technology
 WHERE
   date = CAST('2023-12-01' AS DATE)

--- a/sql/2024/01/ttfb-localized-sites.sql
+++ b/sql/2024/01/ttfb-localized-sites.sql
@@ -13,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+#
 # See https://github.com/GoogleChromeLabs/wpp-research/pull/54
 CREATE TEMP FUNCTION
   IS_GOOD(good FLOAT64,
@@ -33,10 +34,10 @@ WITH
   pages AS (
     SELECT
       client,
-      IS_LOCALIZED(REPLACE(TRIM(LOWER(JSON_VALUE(JSON_VALUE(payload, '$._almanac'), '$.html_node.lang'))), '_', '-' )) AS is_localized,
+      IS_LOCALIZED(REPLACE(TRIM(LOWER(JSON_VALUE(custom_metrics.other.almanac.html_node.lang))), '_', '-' )) AS is_localized,
       page AS url,
     FROM
-      `httparchive.all.pages`,
+      `httparchive.crawl.pages`,
       UNNEST(technologies) AS t
     WHERE
         date = '2023-12-01'

--- a/sql/2024/08/home-page-template-types-popularity.sql
+++ b/sql/2024/08/home-page-template-types-popularity.sql
@@ -30,11 +30,11 @@ CREATE TEMPORARY FUNCTION IS_CMS(technologies ARRAY<STRUCT<technology STRING, ca
   )
 );
 
-CREATE TEMPORARY FUNCTION GET_CONTENT_TYPE(custom_metrics STRING) RETURNS STRUCT<template STRING, postType STRING, taxonomy STRING> AS (
+CREATE TEMPORARY FUNCTION GET_CONTENT_TYPE(cms JSON) RETURNS STRUCT<template STRING, postType STRING, taxonomy STRING> AS (
   STRUCT(
-    CAST(JSON_EXTRACT_SCALAR(custom_metrics, "$.cms.wordpress.content_type.template") AS STRING) AS template,
-    CAST(JSON_EXTRACT_SCALAR(custom_metrics, "$.cms.wordpress.content_type.post_type") AS STRING) AS postType,
-    CAST(JSON_EXTRACT_SCALAR(custom_metrics, "$.cms.wordpress.content_type.taxonomy") AS STRING) AS taxonomy
+    CAST(JSON_VALUE(cms.wordpress.content_type.template) AS STRING) AS template,
+    CAST(JSON_VALUE(cms.wordpress.content_type.post_type) AS STRING) AS postType,
+    CAST(JSON_VALUE(cms.wordpress.content_type.taxonomy) AS STRING) AS taxonomy
   )
 );
 
@@ -44,9 +44,9 @@ WITH contentTypes AS (
     "WordPress" AS cms,
     IF(client = "mobile", "phone", "desktop") AS device,
     page AS url,
-    GET_CONTENT_TYPE(custom_metrics) AS contentType
+    GET_CONTENT_TYPE(custom_metrics.cms) AS contentType
   FROM
-    `httparchive.all.pages`
+    `httparchive.crawl.pages`
   WHERE
     date = DATE_TO_QUERY
     AND IS_CMS(technologies, "WordPress", "")

--- a/sql/2024/12/auto-sizes-wp67-impact-before-after.sql
+++ b/sql/2024/12/auto-sizes-wp67-impact-before-after.sql
@@ -19,7 +19,7 @@
 DECLARE DATE_BEFORE DATE DEFAULT '2024-10-01';
 DECLARE DATE_AFTER DATE DEFAULT '2024-11-01';
 
-CREATE TEMPORARY FUNCTION GET_IMG_SIZES_ACCURACY(custom_metrics STRING) RETURNS
+CREATE TEMPORARY FUNCTION GET_IMG_SIZES_ACCURACY(responsive_images JSON) RETURNS
   ARRAY<STRUCT<url STRING,
   hasSrcset BOOL,
   hasSizes BOOL,
@@ -34,25 +34,25 @@ CREATE TEMPORARY FUNCTION GET_IMG_SIZES_ACCURACY(custom_metrics STRING) RETURNS
 AS (
   ARRAY(
     SELECT AS STRUCT
-      CAST(JSON_EXTRACT_SCALAR(image, '$.url') AS STRING) AS url,
-      CAST(JSON_EXTRACT_SCALAR(image, '$.hasSrcset') AS BOOL) AS hasSrcset,
-      CAST(JSON_EXTRACT_SCALAR(image, '$.hasSizes') AS BOOL) AS hasSizes,
-      CAST(JSON_EXTRACT_SCALAR(image, '$.sizesAbsoluteError') AS FLOAT64) AS sizesAbsoluteError,
-      CAST(JSON_EXTRACT_SCALAR(image, '$.sizesRelativeError') AS FLOAT64) AS sizesRelativeError,
-      CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedPixels') AS INT64) AS idealSizesSelectedResourceEstimatedPixels,
-      CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedPixels') AS INT64) AS actualSizesEstimatedWastedLoadedPixels,
+      CAST(JSON_VALUE(image.url) AS STRING) AS url,
+      CAST(JSON_VALUE(image.hasSrcset) AS BOOL) AS hasSrcset,
+      CAST(JSON_VALUE(image.hasSizes) AS BOOL) AS hasSizes,
+      CAST(JSON_VALUE(image.sizesAbsoluteError) AS FLOAT64) AS sizesAbsoluteError,
+      CAST(JSON_VALUE(image.sizesRelativeError) AS FLOAT64) AS sizesRelativeError,
+      CAST(JSON_VALUE(image.idealSizesSelectedResourceEstimatedPixels) AS INT64) AS idealSizesSelectedResourceEstimatedPixels,
+      CAST(JSON_VALUE(image.actualSizesEstimatedWastedLoadedPixels) AS INT64) AS actualSizesEstimatedWastedLoadedPixels,
       SAFE_DIVIDE(
-        CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedPixels') AS INT64),
-        CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedPixels') AS INT64)
+        CAST(JSON_VALUE(image.actualSizesEstimatedWastedLoadedPixels) AS INT64),
+        CAST(JSON_VALUE(image.idealSizesSelectedResourceEstimatedPixels) AS INT64)
       ) AS relativeSizesEstimatedWastedLoadedPixels,
-      CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedBytes') AS FLOAT64) AS idealSizesSelectedResourceEstimatedBytes,
-      CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedBytes') AS FLOAT64) AS actualSizesEstimatedWastedLoadedBytes,
+      CAST(JSON_VALUE(image.idealSizesSelectedResourceEstimatedBytes) AS FLOAT64) AS idealSizesSelectedResourceEstimatedBytes,
+      CAST(JSON_VALUE(image.actualSizesEstimatedWastedLoadedBytes) AS FLOAT64) AS actualSizesEstimatedWastedLoadedBytes,
       SAFE_DIVIDE(
-        CAST(JSON_EXTRACT_SCALAR(image, '$.actualSizesEstimatedWastedLoadedBytes') AS FLOAT64),
-        CAST(JSON_EXTRACT_SCALAR(image, '$.idealSizesSelectedResourceEstimatedBytes') AS FLOAT64)
+        CAST(JSON_VALUE(image.actualSizesEstimatedWastedLoadedBytes) AS FLOAT64),
+        CAST(JSON_VALUE(image.idealSizesSelectedResourceEstimatedBytes) AS FLOAT64)
       ) AS relativeSizesEstimatedWastedLoadedBytes,
     FROM
-      UNNEST(JSON_EXTRACT_ARRAY(custom_metrics, '$.responsive_images.responsive-images')) AS image
+      UNNEST(JSON_QUERY_ARRAY(responsive_images['responsive-images'])) AS image
   )
 );
 
@@ -72,9 +72,9 @@ WITH relevantUrlsAfter AS (
   SELECT
     client,
     page,
-    custom_metrics
+    custom_metrics.responsive_images AS responsive_images
   FROM
-    `httparchive.all.pages`
+    `httparchive.crawl.pages`
   WHERE
     date = DATE_AFTER
     AND is_root_page = TRUE
@@ -85,9 +85,9 @@ relevantUrlsBefore AS (
   SELECT
     client,
     page,
-    before.custom_metrics AS custom_metrics
+    before.custom_metrics.responsive_images AS responsive_images
   FROM
-    `httparchive.all.pages` AS before
+    `httparchive.crawl.pages` AS before
   INNER JOIN
     relevantUrlsAfter AS after
   USING
@@ -106,7 +106,7 @@ imageSizesDataAfter AS (
     image
   FROM
     relevantUrlsAfter,
-    UNNEST(GET_IMG_SIZES_ACCURACY(custom_metrics)) AS image
+    UNNEST(GET_IMG_SIZES_ACCURACY(responsive_images)) AS image
   WHERE
     image.hasSrcset = TRUE
     AND image.hasSizes = TRUE
@@ -120,7 +120,7 @@ imageSizesDataBefore AS (
     image
   FROM
     relevantUrlsBefore,
-    UNNEST(GET_IMG_SIZES_ACCURACY(custom_metrics)) AS image
+    UNNEST(GET_IMG_SIZES_ACCURACY(responsive_images)) AS image
   WHERE
     image.hasSrcset = TRUE
     AND image.hasSizes = TRUE


### PR DESCRIPTION
2 months ago, HTTP Archive introduced a new dataset `httparchive.crawl.*`, which going forward will be the recommended way to query HTTP Archive. [See the announcement.](https://discuss.httparchive.org/t/new-release-httparchive-crawl-dataset/2814)

As of `2024-12-01`, the older datasets (`httparchive.all.*`, and the older monthly tables) are no longer being populated. Furthermore the old datasets will soon be deleted entirely, as mentioned in the announcement.

Since the WPP Research repository is intended as a repository of queries to use for reference, it makes sense to update the queries in the repository to use the new table structure. While we probably don't intend to use most of the existing queries again as is, them serving as a reference is a good reason to make sure they _can_ actually serve as a reference - which as of now is no longer the case. For queries that were already using `httparchive.all.*` this is a very small lift, while for the older queries using the monthly tables it's a bit more effort.

This PR migrates all queries to use the `httparchive.crawl.*` dataset, with the minimal changes needed. Of course some older queries could in principle be optimized, but this is out of scope for the PR. The goal is to simply migrate to the new dataset while maintaining the same query outputs and with minimal changes.

Only a few queries are not updated (yet) as part of this PR because after careful consideration this was considered too much effort:
* [% of WordPress sites that use any web fonts](https://github.com/GoogleChromeLabs/wpp-research/blob/main/sql/2023/01/web-fonts-usage.sql) (see #34)
* [Distribution of number of web fonts used per site](https://github.com/GoogleChromeLabs/wpp-research/blob/main/sql/2023/01/web-fonts-count-distribution.sql) (see #34)
* [% of WordPress sites that use various font-display strategy for any web fonts](https://github.com/GoogleChromeLabs/wpp-research/blob/main/sql/2023/01/font-display-strategy-usage.sql) (see #34)

I have rerun all the queries with the proposed updates and verified that they produce the same results (+/- <0.1% different values due to minor differences in aggregation of the tables themselves).

For another reference, see the educational [WordPress and performance research in HTTP Archive Colab](https://colab.research.google.com/drive/1TmbJhSBuM-gTHA_E_W96pSjraQkFYpyi) which I also updated the other day to use the new `httparchive.crawl.*` dataset.

Last but not least, there is also [documentation about the migration](https://har.fyi/guides/migrating-to-crawl-dataset/).