### PR TITLE
Fix importing web-vitals module from unpkg

### DIFF
--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -453,7 +453,7 @@ async function benchmarkURL(
 	if ( groupedMetrics.webVitals ) {
 		scriptTag = `import { ${ Object.values( groupedMetrics.webVitals )
 			.map( ( value ) => value.listen )
-			.join( ', ' ) } } from "https://unpkg.com/web-vitals@3?module";`;
+			.join( ', ' ) } } from "https://unpkg.com/web-vitals@3/dist/web-vitals.js";`;
 		Object.values( groupedMetrics.webVitals ).forEach( ( value ) => {
 			scriptTag += `${ value.listen }( ( { name, delta } ) => { window.${ value.global } = name === 'CLS' ? delta * 1000 : delta; } );`;
 		} );

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -453,7 +453,7 @@ async function benchmarkURL(
 	if ( groupedMetrics.webVitals ) {
 		scriptTag = `import { ${ Object.values( groupedMetrics.webVitals )
 			.map( ( value ) => value.listen )
-			.join( ', ' ) } } from "https://unpkg.com/web-vitals@3/dist/web-vitals.js";`;
+			.join( ', ' ) } } from "https://unpkg.com/web-vitals@4/dist/web-vitals.js";`;
 		Object.values( groupedMetrics.webVitals ).forEach( ( value ) => {
 			scriptTag += `${ value.listen }( ( { name, delta } ) => { window.${ value.global } = name === 'CLS' ? delta * 1000 : delta; } );`;
 		} );

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -451,9 +451,10 @@ async function benchmarkURL(
 	let scriptTag;
 
 	if ( groupedMetrics.webVitals ) {
-		scriptTag = `import { ${ Object.values( groupedMetrics.webVitals )
+		const imports = Object.values( groupedMetrics.webVitals )
 			.map( ( value ) => value.listen )
-			.join( ', ' ) } } from "https://unpkg.com/web-vitals@4/dist/web-vitals.js";`;
+			.join( ',' );
+		scriptTag = `import { ${ imports } } from "https://unpkg.com/web-vitals@4/dist/web-vitals.js";`;
 		Object.values( groupedMetrics.webVitals ).forEach( ( value ) => {
 			scriptTag += `${ value.listen }( ( { name, delta } ) => { window.${ value.global } = name === 'CLS' ? delta * 1000 : delta; } );`;
 		} );


### PR DESCRIPTION
See https://github.com/GoogleChrome/web-vitals/pull/600

I also noticed that web-vitals was still using v3 when the current version is v4 (as is reflected in `package.json`, updated in #173). So this updates that version as well.