### PR TITLE
Add broadband network conditions emulation to benchmark-web-vitals

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -161,7 +161,7 @@ Loads the provided URLs in a headless browser several times to measure median We
 * `--output` (`-o`): The output format: Either "table" or "csv".
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 * `--throttle-cpu` (`-t`): Enable CPU throttling to emulate slow CPUs.
-* `--network-conditions` (`-c`): Enable emulation of network conditions. Options: "Slow 3G", "Fast 3G", "Slow 4G", "Fast 4G".
+* `--network-conditions` (`-c`): Enable emulation of network conditions. Options: "Slow 3G", "Fast 3G", "Slow 4G", "Fast 4G", "broadband". Note that "Fast 3G" and "Slow 4G" are identical, and this is used in Lighthouse for testing on mobile. The "broadband" value corresponds to what Lighthouse uses for testing on desktop: 10,240 kb/s throughput with 40 ms TCP RTT.
 * `--emulate-device` (`-e`): Emulate a specific device, like "Moto G4" or "iPad". See list of [known devices](https://pptr.dev/api/puppeteer.knowndevices). 
 * `--window-viewport` (`-w`): Specify the viewport window size, like "mobile" (an alias for "412x823") or "desktop" (an alias for "1350x940"). Defaults to "960x700" if no device is being emulated.
 * `--pause-duration`: Specify the number of milliseconds to pause between making requests in order to give the server a chance to catch its breath. This is to prevent CPU from getting increasingly taxed which would progressively reflect poorly on TTFB. It's also provided as an option to be a good netizen when benchmarking a site in the field since the `rnd` query parameter will usually bust page caches.

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -103,7 +103,7 @@ export const options = [
 	{
 		argname: '-c, --network-conditions <predefined>',
 		description:
-			'Enable emulation of network conditions. Options: "Slow 3G", "Fast 3G", "Slow 4G", "Fast 4G".',
+			'Enable emulation of network conditions. Options: "Slow 3G", "Fast 3G", "Slow 4G", "Fast 4G", "broadband".',
 	},
 	{
 		argname: '-e, --emulate-device <device>',
@@ -225,13 +225,29 @@ function getParamsFromOptions( opt ) {
 	}
 
 	if ( opt.networkConditions ) {
-		if ( ! ( opt.networkConditions in PredefinedNetworkConditions ) ) {
+		if ( 'broadband' === opt.networkConditions ) {
+			/**
+			 * Network conditions used for desktop in Lighthouse/PSI.
+			 *
+			 * 10,240 kb/s throughput with 40 ms TCP RTT.
+			 *
+			 * @see https://github.com/paulirish/lighthouse/blob/f0855904aaffaecf3089169449646960782d7e92/core/config/constants.js#L40-L49
+			 * @see https://docs.google.com/document/d/1-p4HSp42REEA5-jCBVB6PqQcVhI1nQIblBCNKhPJUXg/edit?tab=t.0#heading=h.jsap7yf4phk6
+			 * @type {NetworkConditions}
+			 */
+			params.networkConditions = {
+				download: ( 10240 * 1000 ) / 8,
+				upload: ( 10240 * 1000 ) / 8,
+				latency: 40,
+			};
+		} else if ( opt.networkConditions in PredefinedNetworkConditions ) {
+			params.networkConditions =
+				PredefinedNetworkConditions[ opt.networkConditions ];
+		} else {
 			throw new Error(
 				`Unrecognized predefined network condition: ${ opt.networkConditions }`
 			);
 		}
-		params.networkConditions =
-			PredefinedNetworkConditions[ opt.networkConditions ];
 	}
 
 	if ( opt.emulateDevice ) {


### PR DESCRIPTION
This adds a new `broadband` option for emulating network conditions in `benchmark-web-vitals` to correspond with the configuration used with Lighthouse in PageSpeed Insights.