### PR TITLE
Add query for slider/carousel usage

### DIFF
--- a/sql/2025/04/slider-usage.sql
+++ b/sql/2025/04/slider-usage.sql
@@ -1,0 +1,72 @@
+  # HTTP Archive query to get % of WordPress sites using a slider/carousel library.
+  #
+  # WPP Research, Copyright 2025 Google LLC
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #     https://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+
+DECLARE
+  DATE_TO_QUERY DATE DEFAULT '2025-03-01';
+
+CREATE TEMPORARY FUNCTION
+  HAS_TECHNOLOGY(technologies ARRAY<STRUCT<technology STRING,
+    categories ARRAY<STRING>,
+    info ARRAY<STRING>>>,
+    technologyToFind STRING)
+  RETURNS BOOL AS ( EXISTS(
+    SELECT
+      *
+    FROM
+      UNNEST(technologies) AS technology
+    WHERE
+      technology.technology = technologyToFind ) );
+
+CREATE TEMPORARY FUNCTION
+  HAS_SLIDER(technologies ARRAY<STRUCT<technology STRING,
+    categories ARRAY<STRING>,
+    info ARRAY<STRING>>>)
+  RETURNS BOOL AS (
+    EXISTS(
+    SELECT
+      *
+    FROM
+      UNNEST(technologies) AS technology
+    WHERE
+      technology.technology IN (
+        'FlexSlider',
+        'Flickity',
+        'Master Slider',
+        'MetaSlider',
+        'OWL Carousel',
+        'Slick',
+        'Slider Revolution',
+        'Smart Slider 3',
+        'Swiper'
+      )
+    )
+  );
+
+SELECT
+  client,
+  COUNT(page) AS total_wp_sites,
+  COUNT(IF(HAS_SLIDER(technologies), page, NULL)) AS total_slider,
+  COUNT(IF(HAS_SLIDER(technologies), page, NULL)) / COUNT(page) AS pct_total
+FROM
+  `httparchive.crawl.pages`
+WHERE
+  date = DATE_TO_QUERY
+  AND is_root_page
+  AND HAS_TECHNOLOGY(technologies, 'WordPress')
+GROUP BY
+  client
+ORDER BY
+  client

--- a/sql/README.md
+++ b/sql/README.md
@@ -20,6 +20,10 @@ For additional considerations for writing BigQuery queries against HTTP Archive,
 
 ## Query index
 
+### 2025/04
+
+* [% of WordPress sites using sliders/carousels](./2025/04/slider-usage.sql)
+
 ### 2024/12
 
 * [Image sizes attribute impact of using WordPress 6.7](./2024/12/auto-sizes-wp67-impact-before-after.sql)


### PR DESCRIPTION
In the 2025-03-01 dataset, ~54% of all WordPress sites use one of these slider/carousel libraries.

The list of plugins/libraries is based on some manual research and is not meant to be exhaustive.

This is relevant for things like https://core.trac.wordpress.org/ticket/63251

I am sharing these numbers in an upcoming blog post and need to store the query somewhere, so here I am :)