### PR TITLE
Implement HTTP Archive query to assess usage of `Featured Image` in block themes

### DIFF
--- a/sql/2025/05/featured-image-block-usage.sql
+++ b/sql/2025/05/featured-image-block-usage.sql
@@ -34,7 +34,8 @@ CREATE TEMPORARY FUNCTION IS_CMS(technologies ARRAY<STRUCT<technology STRING, ca
 WITH wordpress AS (
   SELECT
     client,
-    page
+    page,
+    BOOL(custom_metrics.cms.wordpress.block_theme) AS has_block_theme
   FROM
     `httparchive.crawl.pages`
   WHERE
@@ -60,7 +61,9 @@ featuredImageBlockDetection AS (
 SELECT
   client,
   COUNT(IF(has_featured_image_block, page, NULL)) AS urls,
+  COUNT(IF(has_block_theme, page, NULL)) AS block_theme,
   COUNT(page) AS total,
+  COUNT(IF(has_featured_image_block, page, NULL)) / COUNT(IF(has_block_theme, page, NULL)) AS pct_block_theme,
   COUNT(IF(has_featured_image_block, page, NULL)) / COUNT(page) AS pct_total
 FROM
   wordpress

--- a/sql/2025/05/featured-image-block-usage.sql
+++ b/sql/2025/05/featured-image-block-usage.sql
@@ -1,0 +1,61 @@
+# HTTP Archive query to get % WordPress sites using a block theme.
+#
+# WPP Research, Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/184
+SELECT
+  client,
+  COUNT(DISTINCT page) AS with_block_theme,
+  total_wp_sites,
+  COUNT(DISTINCT url) / total_wp_sites AS pct_total,
+  # For reference, include number of sites greater than or equal to WP 5.9, since only then block theme support was launched.
+  wp_gte_59
+FROM
+  `httparchive.crawl.pages`,
+  UNNEST(technologies) AS technology,
+  UNNEST(technology.info) AS version
+JOIN
+  `httparchive.crawl.requests`
+USING
+  (date, client, page, is_root_page)
+JOIN (
+  SELECT
+    client,
+    COUNT(DISTINCT IF (version = '' OR CAST(REGEXP_EXTRACT(version, r'^(\d+\.\d+)') AS FLOAT64) >= 5.9, page, NULL)) AS wp_gte_59,
+    COUNT(DISTINCT page) AS total_wp_sites
+  FROM
+    `httparchive.crawl.pages`,
+    UNNEST(technologies) AS technology,
+    UNNEST(technology.info) AS version
+  WHERE
+    date = '2025-03-01'
+    AND is_root_page
+    AND technology.technology = "WordPress"
+  GROUP BY
+    client )
+USING
+  (client)
+WHERE
+  date = '2025-03-01'
+  AND is_root_page
+  AND technology.technology = "WordPress"
+  AND (version = '' OR CAST(REGEXP_EXTRACT(version, r'^(\d+\.\d+)') AS FLOAT64) >= 5.9)
+  AND response_body LIKE '%<figure class="wp-block-post-featured-image">%'
+GROUP BY
+  client,
+  wp_gte_59,
+  total_wp_sites
+ORDER BY
+  client

--- a/sql/2025/05/featured-image-block-usage.sql
+++ b/sql/2025/05/featured-image-block-usage.sql
@@ -1,4 +1,4 @@
-# HTTP Archive query to get % WordPress sites using a block theme.
+# HTTP Archive query to get % WordPress sites using Featured Image in block themes.
 #
 # WPP Research, Copyright 2025 Google LLC
 #

--- a/sql/2025/05/featured-image-block-usage.sql
+++ b/sql/2025/05/featured-image-block-usage.sql
@@ -17,7 +17,7 @@
 # See query results here: https://github.com/GoogleChromeLabs/wpp-research/pull/184
 
 DECLARE
-  DATE_TO_QUERY DATE DEFAULT '2025-03-01';
+  DATE_TO_QUERY DATE DEFAULT '2025-04-01';
 
 CREATE TEMPORARY FUNCTION IS_CMS(technologies ARRAY<STRUCT<technology STRING, categories ARRAY<STRING>, info ARRAY<STRING>>>, cms STRING, version STRING) RETURNS BOOL AS (
   EXISTS(
@@ -39,7 +39,7 @@ WITH wordpress AS (
     `httparchive.crawl.pages`
   WHERE
     date = DATE_TO_QUERY
-    AND IS_CMS(technologies, 'WordPress', '5.9.0')
+    AND IS_CMS(technologies, 'WordPress', '')
     AND is_root_page = TRUE
 ),
 
@@ -54,6 +54,7 @@ featuredImageBlockDetection AS (
     date = DATE_TO_QUERY
     AND is_root_page = TRUE
     AND is_main_document
+    AND response_body LIKE '%<div class="wp-site-blocks">%'
 )
 
 SELECT

--- a/sql/2025/05/featured-image-block-usage.sql
+++ b/sql/2025/05/featured-image-block-usage.sql
@@ -48,14 +48,14 @@ featuredImageBlockDetection AS (
   SELECT
     client,
     page,
-    REGEXP_CONTAINS(response_body, r'<figure class="wp-block-post-featured-image">') AS has_featured_image_block
+    TRUE AS has_featured_image_block
   FROM
     `httparchive.crawl.requests`
   WHERE
     date = DATE_TO_QUERY
     AND is_root_page = TRUE
     AND is_main_document
-    AND response_body LIKE '%<div class="wp-site-blocks">%'
+    AND REGEXP_CONTAINS(response_body, r'<figure class="wp-block-post-featured-image">')
 )
 
 SELECT
@@ -67,7 +67,7 @@ SELECT
   COUNT(IF(has_featured_image_block, page, NULL)) / COUNT(page) AS pct_total
 FROM
   wordpress
-JOIN
+LEFT JOIN
   featuredImageBlockDetection
 USING
   (client, page)

--- a/sql/README.md
+++ b/sql/README.md
@@ -20,6 +20,10 @@ For additional considerations for writing BigQuery queries against HTTP Archive,
 
 ## Query index
 
+### 2025/05
+
+* [% of WordPress sites using featured image block](./2025/05/featured-image-block-usage.sql)
+
 ### 2025/04
 
 * [% of WordPress sites using sliders/carousels](./2025/04/slider-usage.sql)


### PR DESCRIPTION
Fixes #183 

This query identifies sites using a `Featured Image` in block themes by checking for the `<figure class="wp-block-post-featured-image">` tag which is present in all such sites, as controlled by WordPress core.

## Query results

Row | client | urls | block_theme | total | pct_block_theme | pct_total
-- | -- | -- | -- | -- | -- | --
1 | desktop | 5806 | 99881 | 4573341 | 0.0581291737167229 | 0.0012695313994736015
2 | mobile | 6848 | 127599 | 5595207 | 0.053668132195393382 | 0.0012239046741255506

Based on April 2025 dataset