### PR TITLE
Introduce Markdown output format

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -28,7 +28,7 @@ By default, only the median values are returned. You can optionally request all 
 
 * `--test` (`-t`): You need to pass a WebPageTest result ID (e.g. "221011_AiDcV7_GGM") or URL (e.g. "https://www.webpagetest.org/result/221011_AiDcV7_GGM/"). You can optionally pass multiple test result IDs to merge their metrics. This is usually not relevant but can be helpful to combine multiple results with similar test configuration, to effectively have more test runs than the limit of 9 that WebPageTest imposes.
 * `--metrics` (`-m`): You need to pass one or more WebPageTest metrics. Any metrics available on the "Graph Page Data" view (e.g. "https://www.webpagetest.org/graph_page_data.php?tests=221011_AiDcV7_GGM&median_value=1") are available. For a full list, please see the source code of the `createGetSingleMetricValue_()` function in the `lib/wpt/result.mjs` file. Additionally, you can access any Server-Timing metric by its identifier prefixed with "Server-Timing:". You can even aggregate multiple metrics in one via addition (` + `) and/or subtraction (` - `). Make sure to include a space before and after the arithmetic operator.
-* `--format` (`-f`): The output format: Either "table" or "csv".
+* `--format` (`-f`): The output format: Either "table", "csv", or "md".
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 * `--include-runs` (`-i`): Whether to also show the full results for all runs.
 * `--rows-as-columns` (`-r`): Whether to inverse rows and columns.
@@ -86,7 +86,7 @@ By default, only the median values are returned. You can optionally request all 
 #### Arguments
 
 * `--test` (`-t`): You need to pass a WebPageTest result ID (e.g. "221011_AiDcV7_GGM") or URL (e.g. "https://www.webpagetest.org/result/221011_AiDcV7_GGM/"). You can optionally pass multiple test result IDs to merge their metrics. This is usually not relevant but can be helpful to combine multiple results with similar test configuration, to effectively have more test runs than the limit of 9 that WebPageTest imposes.
-* `--format` (`-f`): The output format: Either "table" or "csv".
+* `--format` (`-f`): The output format: Either "table", "csv", or "md".
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 * `--include-runs` (`-i`): Whether to also show the full results for all runs.
 * `--rows-as-columns` (`-r`): Whether to inverse rows and columns.
@@ -123,7 +123,7 @@ Sends the selected number of requests with a certain concurrency to provided URL
 * `--concurrency` (`-c`): Number of requests to make at the same time.
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
-* `--output` (`-o`): The output format: Either "table" or "csv".
+* `--output` (`-o`): The output format: Either "table", "csv", or "md".
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 
 #### Examples
@@ -158,7 +158,7 @@ Loads the provided URLs in a headless browser several times to measure median We
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
 * `--metrics` (`-m`): Which metrics to include; by default these are "FCP", "LCP", "TTFB" and "LCP-TTFB".
-* `--output` (`-o`): The output format: Either "table" or "csv".
+* `--output` (`-o`): The output format: Either "table", "csv", or "md".
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 * `--throttle-cpu` (`-t`): Enable CPU throttling to emulate slow CPUs.
 * `--network-conditions` (`-c`): Enable emulation of network conditions. Options: "Slow 3G", "Fast 3G", "Slow 4G", "Fast 4G", "broadband". Note that "Fast 3G" and "Slow 4G" are identical, and this is used in Lighthouse for testing on mobile. The "broadband" value corresponds to what Lighthouse uses for testing on desktop: 10,240 kb/s throughput with 40 ms TCP RTT.
@@ -211,7 +211,7 @@ Loads the given URL with both desktop and mobile emulation and gathers informati
 #### Arguments
 
 * `--url` (`-u`): A URL to analyze.
-* `--output` (`-o`): The output format, either "table", "json", "csv", or "csv-oneline".
+* `--output` (`-o`): The output format, either "table", "json", "csv", "csv-oneline", or "md".
 
 #### Examples
 

--- a/cli/commands/analyze-loading-optimization.mjs
+++ b/cli/commands/analyze-loading-optimization.mjs
@@ -76,7 +76,7 @@ export const options = [
 	},
 	{
 		argname: '-o, --output <output>',
-		description: 'Output format: csv, csv-oneline, table, or json', // TODO: Add ability to output CSV as single row for sake of putting in spreadsheet.
+		description: 'Output format: csv, csv-oneline, table, md, or json', // TODO: Add ability to output CSV as single row for sake of putting in spreadsheet.
 		defaults: OUTPUT_FORMAT_TABLE,
 	},
 ];
@@ -104,7 +104,7 @@ function getParamsFromOptions( opt ) {
 		! [ 'csv-oneline', 'json' ].includes( params.output )
 	) {
 		throw new Error(
-			`Invalid output ${ opt.output }. The output format provided via the --output (-o) argument must be either "table", "csv", "csv-oneline", or "json".`
+			`Invalid output ${ opt.output }. The output format provided via the --output (-o) argument must be either "table", "csv", "csv-oneline", "json", or "md".`
 		);
 	}
 

--- a/cli/commands/analyze-loading-optimization.mjs
+++ b/cli/commands/analyze-loading-optimization.mjs
@@ -76,7 +76,7 @@ export const options = [
 	},
 	{
 		argname: '-o, --output <output>',
-		description: 'Output format: csv, csv-oneline, table, md, or json', // TODO: Add ability to output CSV as single row for sake of putting in spreadsheet.
+		description: 'Output format: csv, csv-oneline, table, md, or json',
 		defaults: OUTPUT_FORMAT_TABLE,
 	},
 ];

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -348,16 +348,5 @@ function outputResults( opt, results ) {
 		tableData.push( tableRow );
 	}
 
-	// Format the numbers with a consistent number of decimal points.
-	if ( opt.output === 'table' || opt.output === 'md' ) {
-		tableData.forEach( ( row ) => {
-			for ( let i = 1; i < row.length; i++ ) {
-				if ( typeof row[ i ] === 'number' ) {
-					row[ i ] = row[ i ].toFixed( 2 );
-				}
-			}
-		} );
-	}
-
 	output( table( headings, tableData, opt.output, true ) );
 }

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -66,7 +66,7 @@ export const options = [
 	},
 	{
 		argname: '-o, --output <output>',
-		description: 'Output format: csv or table',
+		description: 'Output format: "csv", "table", "md"',
 		defaults: OUTPUT_FORMAT_TABLE,
 	},
 	{
@@ -84,7 +84,7 @@ export async function handler( opt ) {
 	if ( ! isValidTableFormat( opt.output ) ) {
 		log(
 			formats.error(
-				'The output format provided via the --output (-o) argument must be either "table" or "csv".'
+				`Invalid output ${ opt.output }. The output format provided via the --output (-o) argument must be either "table", "csv", or "md".`
 			)
 		);
 		return;
@@ -346,6 +346,17 @@ function outputResults( opt, results ) {
 		} );
 
 		tableData.push( tableRow );
+	}
+
+	// Format the numbers with a consistent number of decimal points.
+	if ( opt.output === 'table' || opt.output === 'md' ) {
+		tableData.forEach( ( row ) => {
+			for ( let i = 1; i < row.length; i++ ) {
+				if ( typeof row[ i ] === 'number' ) {
+					row[ i ] = row[ i ].toFixed( 2 );
+				}
+			}
+		} );
 	}
 
 	output( table( headings, tableData, opt.output, true ) );

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -828,18 +828,6 @@ function outputResults( opt, results ) {
 		tableData.push( tableRow );
 	}
 
-	// Format the numbers with a consistent number of decimal points.
-	if ( opt.output === 'table' || opt.output === 'md' ) {
-		const precision = opt.showVariance ? 2 : 1;
-		tableData.forEach( ( row ) => {
-			for ( let i = 1; i < row.length; i++ ) {
-				if ( typeof row[ i ] === 'number' ) {
-					row[ i ] = row[ i ].toFixed( precision );
-				}
-			}
-		} );
-	}
-
 	output( table( headings, tableData, opt.output, true ) );
 }
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -84,7 +84,7 @@ export const options = [
 	},
 	{
 		argname: '-o, --output <output>',
-		description: 'Output format: csv or table',
+		description: 'Output format: "csv", "table", "md"',
 		defaults: OUTPUT_FORMAT_TABLE,
 	},
 	{
@@ -205,7 +205,7 @@ function getParamsFromOptions( opt ) {
 
 	if ( ! isValidTableFormat( params.output ) ) {
 		throw new Error(
-			`Invalid output ${ opt.output }. The output format provided via the --output (-o) argument must be either "table" or "csv".`
+			`Invalid output ${ opt.output }. The output format provided via the --output (-o) argument must be either "table", "csv", or "md".`
 		);
 	}
 
@@ -826,6 +826,18 @@ function outputResults( opt, results ) {
 		} );
 
 		tableData.push( tableRow );
+	}
+
+	// Format the numbers with a consistent number of decimal points.
+	if ( opt.output === 'table' || opt.output === 'md' ) {
+		const precision = opt.showVariance ? 2 : 1;
+		tableData.forEach( ( row ) => {
+			for ( let i = 1; i < row.length; i++ ) {
+				if ( typeof row[ i ] === 'number' ) {
+					row[ i ] = row[ i ].toFixed( precision );
+				}
+			}
+		} );
 	}
 
 	output( table( headings, tableData, opt.output, true ) );

--- a/cli/commands/wpt-metrics.mjs
+++ b/cli/commands/wpt-metrics.mjs
@@ -57,7 +57,7 @@ export const options = [
 	},
 	{
 		argname: '-f, --format <format>',
-		description: 'Output format: Either "table" or "csv"',
+		description: 'Output format: "csv", "table", "md"',
 		defaults: OUTPUT_FORMAT_TABLE,
 	},
 	{
@@ -96,7 +96,7 @@ export async function handler( opt ) {
 	if ( ! isValidTableFormat( format ) ) {
 		log(
 			formats.error(
-				'The output format provided via the --format (-f) argument must be either "table" or "csv".'
+				`Invalid output ${ format }. The output format provided via the --output (-o) argument must be either "table", "csv", or "md".`
 			)
 		);
 		return;

--- a/cli/commands/wpt-server-timing.mjs
+++ b/cli/commands/wpt-server-timing.mjs
@@ -52,7 +52,7 @@ export const options = [
 	},
 	{
 		argname: '-f, --format <format>',
-		description: 'Output format: Either "table" or "csv"',
+		description: 'Output format: "csv", "table", "md"',
 		defaults: OUTPUT_FORMAT_TABLE,
 	},
 	{
@@ -84,7 +84,7 @@ export async function handler( opt ) {
 	if ( ! isValidTableFormat( format ) ) {
 		log(
 			formats.error(
-				'The output format provided via the --format (-f) argument must be either "table" or "csv".'
+				`Invalid output ${ format }. The output format provided via the --output (-o) argument must be either "table", "csv", or "md".`
 			)
 		);
 		return;

--- a/cli/lib/cli/logger.mjs
+++ b/cli/lib/cli/logger.mjs
@@ -22,6 +22,7 @@
 import chalk from 'chalk';
 import { table as formatTable } from 'table';
 import { stringify as formatCsv } from 'csv-stringify/sync'; // eslint-disable-line import/no-unresolved
+import { markdownTable } from 'markdown-table';
 
 // Responsible for the actual command output.
 export const output = ( text ) => {
@@ -47,9 +48,10 @@ export const formats = {
 
 export const OUTPUT_FORMAT_TABLE = 'table';
 export const OUTPUT_FORMAT_CSV = 'csv';
+export const OUTPUT_FORMAT_MD = 'md';
 
 export function isValidTableFormat( format ) {
-	return format === OUTPUT_FORMAT_TABLE || format === OUTPUT_FORMAT_CSV;
+	return format === OUTPUT_FORMAT_TABLE || format === OUTPUT_FORMAT_CSV || format === OUTPUT_FORMAT_MD;
 }
 
 export function table( headings, data, format, rowsAsColumns ) {
@@ -79,6 +81,10 @@ export function table( headings, data, format, rowsAsColumns ) {
 
 	if ( format === OUTPUT_FORMAT_CSV ) {
 		return formatCsv( tableData );
+	} else if ( format === OUTPUT_FORMAT_MD ) {
+		// Align the first column to the left, but align all remaining columns to the right since they are numeric.
+		const align = [ 'l', ...Array( headings.length - 1 ).fill( 'r' ) ];
+		return markdownTable( tableData, { align } );
 	}
 
 	return formatTable( tableData );

--- a/cli/lib/cli/logger.mjs
+++ b/cli/lib/cli/logger.mjs
@@ -51,7 +51,11 @@ export const OUTPUT_FORMAT_CSV = 'csv';
 export const OUTPUT_FORMAT_MD = 'md';
 
 export function isValidTableFormat( format ) {
-	return format === OUTPUT_FORMAT_TABLE || format === OUTPUT_FORMAT_CSV || format === OUTPUT_FORMAT_MD;
+	return (
+		format === OUTPUT_FORMAT_TABLE ||
+		format === OUTPUT_FORMAT_CSV ||
+		format === OUTPUT_FORMAT_MD
+	);
 }
 
 export function table( headings, data, format, rowsAsColumns ) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "commander": "^12.1.0",
         "csv-stringify": "^6.5.1",
         "lodash-es": "4.17.21",
+        "markdown-table": "^3.0.4",
         "puppeteer": "^23.3.1",
         "table": "^6.8.2",
         "web-vitals": "4.2.4"
@@ -14917,6 +14918,17 @@
       "license": "BSD-2-Clause",
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/markdownlint": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "commander": "^12.1.0",
     "csv-stringify": "^6.5.1",
     "lodash-es": "4.17.21",
+    "markdown-table": "^3.0.4",
     "puppeteer": "^23.3.1",
     "table": "^6.8.2",
     "web-vitals": "4.2.4"


### PR DESCRIPTION
In order to format the output of running various commands into Markdown for pasting in GitHub issues, I would often copy the CSV into a Google Sheet, and then copy from the sheet into GitHub. I'd then have to manually add the necessary column alignments and tidy things up (like remove the `style` tag that Google Sheets also outputs). So this PR introduces the `md` output format to go alongside the default `table` and `csv` formats.

```bash
npm run research -- benchmark-server-timing -u http://localhost:10008/bison/ -n 50 -o md
```

Output:

| URL                         | http://localhost:10008/bison/ |
| :-------------------------- | ----------------------------: |
| Success Rate                |                          100% |
| Response Time (median)      |                         20.12 |
| wp-before-template (median) |                          7.07 |
| wp-template (median)        |                         12.14 |
| wp-total (median)           |                         19.24 |

```bash
npm run research -- benchmark-web-vitals --file=urls.txt -n 50 -o md -c broadband
```

Output:

| URL               | http://localhost:10008/bison/?disable_script_fetchpriority_low=1 | http://localhost:10008/bison/ |
| :---------------- | ---------------------------------------------------------------: | ----------------------------: |
| Success Rate      |                                                             100% |                          100% |
| FCP (median)      |                                                            141.5 |                         138.8 |
| LCP (median)      |                                                            409.9 |                         379.2 |
| TTFB (median)     |                                                             35.9 |                          35.8 |
| LCP-TTFB (median) |                                                            373.6 |                         343.8 |