### PR TITLE
Add `--diff` argument to `benchmark-web-vitals` and `benchmark-server-timing`

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -123,6 +123,7 @@ Sends the selected number of requests with a certain concurrency to provided URL
 * `--concurrency` (`-c`): Number of requests to make at the same time.
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
+* `--diff` (`-d`): Add diffs in terms of milliseconds and percentages when two URLs are provided via `--file`.
 * `--output` (`-o`): The output format: Either "table", "csv", or "md".
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 
@@ -157,6 +158,7 @@ Loads the provided URLs in a headless browser several times to measure median We
 * `--url` (`-u`): A URL to benchmark.
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
+* `--diff` (`-d`): Add diffs in terms of milliseconds and percentages when two URLs are provided via `--file`.
 * `--metrics` (`-m`): Which metrics to include; by default these are "FCP", "LCP", "TTFB" and "LCP-TTFB".
 * `--output` (`-o`): The output format: Either "table", "csv", or "md".
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -27,6 +27,7 @@ import round from 'lodash-es/round.js';
  */
 import { getURLs, shouldLogURLProgress } from '../lib/cli/args.mjs';
 import {
+	amendDiffsToTableData,
 	log,
 	logPartial,
 	output,
@@ -63,6 +64,12 @@ export const options = [
 	{
 		argname: '-f, --file <file>',
 		description: 'File with URLs to run benchmark tests for',
+	},
+	{
+		argname: '-d, --diff',
+		description:
+			'Compute the difference between two URLs. Only applicable when using --file and two URLs are provided.',
+		defaults: false,
 	},
 	{
 		argname: '-o, --output <output>',
@@ -346,6 +353,19 @@ function outputResults( opt, results ) {
 		} );
 
 		tableData.push( tableRow );
+	}
+
+	// When two URLs are being benchmarked and the --diff option is provided, add columns for the millisecond diff and percentage diff.
+	if ( opt.diff ) {
+		if ( tableData.length !== 2 ) {
+			log(
+				formats.error(
+					`The --diff option was ignored because you provided ${ results.length } URL(s), but it requires two URLs to compare.`
+				)
+			);
+		} else {
+			amendDiffsToTableData( tableData );
+		}
 	}
 
 	output( table( headings, tableData, opt.output, true ) );

--- a/cli/lib/cli/args.mjs
+++ b/cli/lib/cli/args.mjs
@@ -42,12 +42,6 @@ export function parseWptTestId( testIdOrUrl ) {
 	return testId;
 }
 
-/**
- * Gets URLs.
- *
- * @param {{ url: ?string, file: ?string }} opt
- * @returns {AsyncGenerator<string>}
- */
 export async function* getURLs( opt ) {
 	if ( !! opt.url ) {
 		yield opt.url;

--- a/cli/lib/cli/args.mjs
+++ b/cli/lib/cli/args.mjs
@@ -42,6 +42,12 @@ export function parseWptTestId( testIdOrUrl ) {
 	return testId;
 }
 
+/**
+ * Gets URLs.
+ *
+ * @param {{ url: ?string, file: ?string }} opt
+ * @returns {AsyncGenerator<string>}
+ */
 export async function* getURLs( opt ) {
 	if ( !! opt.url ) {
 		yield opt.url;

--- a/cli/lib/cli/logger.mjs
+++ b/cli/lib/cli/logger.mjs
@@ -58,6 +58,48 @@ export function isValidTableFormat( format ) {
 	);
 }
 
+/**
+ * Amends the table data with milliseconds and percent diffs.
+ *
+ * @param {Array<Array<number|string>>} tableData
+ */
+export function amendDiffsToTableData( tableData ) {
+	if ( tableData.length !== 2 ) {
+		throw new Error( 'Table data must have exactly two rows.' );
+	}
+
+	const msDiffs = [ 'Diff (ms)' ];
+	const percentDiffs = [ 'Diff (%)' ];
+
+	// Note: rowIndex starts at 1 to skip over the URL row.
+	for ( let rowIndex = 1; rowIndex < tableData[ 0 ].length; rowIndex++ ) {
+		const first = tableData[ 0 ][ rowIndex ];
+		const second = tableData[ 1 ][ rowIndex ];
+		if ( typeof first !== 'number' || typeof second !== 'number' ) {
+			msDiffs.push( '--' );
+			percentDiffs.push( '--' );
+		} else {
+			const diffMs = second - first;
+			const diffPercent = ( ( second - first ) / first ) * 100;
+
+			let prefix = '';
+			if ( diffMs < 0 ) {
+				prefix = '-';
+			} else if ( diffMs > 0 ) {
+				prefix = '+';
+			}
+
+			msDiffs.push( prefix + Math.abs( diffMs ).toFixed( 2 ) );
+			percentDiffs.push(
+				prefix + Math.abs( diffPercent ).toFixed( 1 ) + '%'
+			);
+		}
+	}
+
+	tableData.push( msDiffs );
+	tableData.push( percentDiffs );
+}
+
 export function table( headings, data, format, rowsAsColumns ) {
 	const tableData = [];
 


### PR DESCRIPTION
This is a follow-up to https://github.com/GoogleChromeLabs/wpp-research/pull/186. 

The most common use case for benchmarking two URLs is to see the performance impact before/after. To do this, I would often copy the CSV output into a Google Sheet and then add columns to compute the difference in terms of milliseconds and percentage. Since this is such a common scenario (at least for me), this PR adds support for passing `--diff` when calling `benchmark-web-vitals` or `benchmark-server-timing`, if the `--file` arg is referring to a file that contains two URLs.

Example output:

```bash
npm run research -- benchmark-web-vitals --file="urls.txt" --number=100 --output="md" --network-conditions="broadband" --diff
```

| URL               | http://localhost:10008/bison/?disable_script_fetchpriority_low=1 | http://localhost:10008/bison/ | Diff (ms) | Diff (%) |
|:------------------|-----------------------------------------------------------------:|------------------------------:|----------:|---------:|
| Success Rate      |                                                             100% |                          100% |        -- |       -- |
| FCP (median)      |                                                           142.55 |                         141.7 |     -0.85 |    -0.6% |
| LCP (median)      |                                                           409.35 |                        382.35 |    -27.00 |    -6.6% |
| TTFB (median)     |                                                            34.65 |                          35.3 |     +0.65 |    +1.9% |
| LCP-TTFB (median) |                                                           374.15 |                           347 |    -27.15 |    -7.3% |