### PR TITLE
Catch Puppeteer errors to count toward non-success rate in benchmark-web-vitals

### DIFF
--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -569,14 +569,7 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 			}
 
 			if ( response.status() !== 200 ) {
-				if ( logProgress ) {
-					log(
-						formats.error(
-							`Error: Bad response code ${ response.status() }.`
-						)
-					);
-				}
-				continue;
+				throw new Error( `Bad response code ${ response.status() }.` );
 			}
 
 			if ( groupedMetrics.webVitals ) {

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -28,7 +28,6 @@ import round from 'lodash-es/round.js';
 /* eslint-disable jsdoc/valid-types */
 /** @typedef {import("puppeteer").NetworkConditions} NetworkConditions */
 /** @typedef {import("puppeteer").Browser} Browser */
-/** @typedef {import("puppeteer").Page} Page */
 /** @typedef {keyof typeof PredefinedNetworkConditions} NetworkConditionName */
 /** @typedef {import("puppeteer").Device} Device */
 /** @typedef {keyof typeof KnownDevices} KnownDeviceName */
@@ -518,9 +517,6 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 		/** @type {Browser} */
 		let browser;
 
-		/** @type {Page} */
-		let page;
-
 		try {
 			browser = await launchBrowser();
 			if ( logProgress ) {
@@ -528,7 +524,7 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 					`Benchmarking ${ requestNum + 1 } / ${ params.amount }...`
 				);
 			}
-			page = await browser.newPage();
+			const page = await browser.newPage();
 			await page.setBypassCSP( true ); // Bypass CSP so the web vitals script tag can be injected below.
 			if ( params.cpuThrottleFactor ) {
 				await page.emulateCPUThrottling( params.cpuThrottleFactor );


### PR DESCRIPTION
Very often when I do `benchmark-web-vitals` while emulating slow network conditions, I'll end up in a case where the results get truncated due to an exception thrown in `benchmarkURL()` which is not caught:

```
...
Benchmarking 37 / 100...Success.
Benchmarking 38 / 100...Success.
Benchmarking 39 / 100...Success.
Benchmarking 40 / 100...Error: Navigation timeout of 30000 ms exceeded.
Benchmarking URL http://localhost:10008/bison/...
Priming network...
Benchmarking 1 / 100...Success.
Benchmarking 2 / 100...Success.
Benchmarking 3 / 100...Success.
...
```

In reality, such exceptions should count toward the non-success rate the same as a non-200 response. So this PR adds a `try`/`catch` block around the Puppeteer logic so that such errors are properly handled. The `completeRequests` counter is only incremented when no more calls to Puppeteer are needed.

This PR should be removed with whitespace changes omitted.