### PR TITLE
Allow passing multiple `--url` args when benchmarking instead of needing to use `--file` to benchmark multiple URLs

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -119,7 +119,7 @@ Sends the selected number of requests with a certain concurrency to provided URL
 
 #### Arguments
 
-* `--url` (`-u`): A URL to benchmark.
+* `--url` (`-u`): A URL to benchmark. Multiple URLs may be specified by repeating this argument.
 * `--concurrency` (`-c`): Number of requests to make at the same time.
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
@@ -154,7 +154,7 @@ Loads the provided URLs in a headless browser several times to measure median We
 
 #### Arguments
 
-* `--url` (`-u`): A URL to benchmark.
+* `--url` (`-u`): A URL to benchmark. Multiple URLs may be specified by repeating this argument.
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
 * `--metrics` (`-m`): Which metrics to include; by default these are "FCP", "LCP", "TTFB" and "LCP-TTFB".

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -25,7 +25,11 @@ import round from 'lodash-es/round.js';
 /**
  * Internal dependencies
  */
-import { getURLs, shouldLogURLProgress } from '../lib/cli/args.mjs';
+import {
+	collectUrlArgs,
+	getURLs,
+	shouldLogURLProgress,
+} from '../lib/cli/args.mjs';
 import {
 	log,
 	logPartial,
@@ -48,7 +52,10 @@ import {
 export const options = [
 	{
 		argname: '-u, --url <url>',
-		description: 'A URL to run benchmark tests for',
+		description:
+			'URL to run benchmark tests for, where multiple URLs can be supplied by repeating the argument',
+		defaults: [],
+		parseArg: collectUrlArgs,
 	},
 	{
 		argname: '-c, --concurrency <concurrency>',
@@ -120,7 +127,7 @@ export async function handler( opt ) {
 	if ( results.length === 0 ) {
 		log(
 			formats.error(
-				'You need to provide a URL to benchmark via the --url (-u) argument, or a file with multiple URLs via the --file (-f) argument.'
+				'You need to provide a URL to benchmark via one or more --url (-u) arguments, or a file with one or more URLs via the --file (-f) argument.'
 			)
 		);
 	} else {

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -98,7 +98,7 @@ export async function handler( opt ) {
 
 	for await ( const url of getURLs( opt ) ) {
 		if ( logURLProgress ) {
-			logPartial( `Benchmarking URL ${ url }...` );
+			logPartial( `Benchmarking URL ${ url } ... ` );
 		}
 
 		try {

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -416,9 +416,9 @@ export async function handler( opt ) {
 		if ( logURLProgress ) {
 			// If also logging individual iterations, put those on a new line.
 			if ( logIterationsProgress ) {
-				log( `Benchmarking URL ${ url }...` );
+				log( `Benchmarking URL ${ url } ... ` );
 			} else {
-				logPartial( `Benchmarking URL ${ url }...` );
+				logPartial( `Benchmarking URL ${ url } ... ` );
 			}
 		}
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -444,12 +444,10 @@ export async function handler( opt ) {
 					} else {
 						log( formats.success( message ) );
 					}
+				} else if ( 0 === completeRequests ) {
+					log( formats.error( 'Failure.' ) );
 				} else {
-					if ( 0 === completeRequests ) {
-						log( formats.error( 'Failure.' ) );
-					} else {
-						log( formats.success( 'Success.' ) );
-					}
+					log( formats.success( 'Success.' ) );
 				}
 			}
 		} catch ( err ) {

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -41,6 +41,7 @@ import round from 'lodash-es/round.js';
  */
 import {
 	getURLs,
+	collectUrlArgs,
 	shouldLogURLProgress,
 	shouldLogIterationsProgress,
 } from '../lib/cli/args.mjs';
@@ -66,7 +67,10 @@ import {
 export const options = [
 	{
 		argname: '-u, --url <url>',
-		description: 'A URL to run benchmark tests for',
+		description:
+			'URL to run benchmark tests for, where multiple URLs can be supplied by repeating the argument',
+		defaults: [],
+		parseArg: collectUrlArgs,
 	},
 	{
 		argname: '-n, --number <number>',
@@ -129,7 +133,7 @@ export const options = [
 
 /**
  * @typedef {Object} Params
- * @property {?string}             url                - See above.
+ * @property {string[]}            url                - See above.
  * @property {number}              amount             - See above.
  * @property {?string}             file               - See above.
  * @property {?string[]}           metrics            - See above.
@@ -156,7 +160,7 @@ export const options = [
 
 /**
  * @param {Object}        opt
- * @param {?string}       opt.url
+ * @param {string[]}      opt.url
  * @param {string|number} opt.number
  * @param {?string}       opt.file
  * @param {?string[]}     opt.metrics
@@ -209,9 +213,9 @@ function getParamsFromOptions( opt ) {
 		);
 	}
 
-	if ( ! params.file && ! params.url ) {
+	if ( ! params.file && params.url.length === 0 ) {
 		throw new Error(
-			'You need to provide a URL to benchmark via the --url (-u) argument, or a file with multiple URLs via the --file (-f) argument.'
+			'You need to provide a URL to benchmark via one or more --url (-u) arguments, or a file with one or more URLs via the --file (-f) argument.'
 		);
 	}
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -434,13 +434,18 @@ export async function handler( opt ) {
 			if ( logURLProgress ) {
 				// If also logging individual iterations, provide more context on benchmarking which URL was completed.
 				if ( logIterationsProgress ) {
-					log(
-						formats.success(
-							`Completed benchmarking URL ${ url }.`
-						)
-					);
+					const message = `Completed benchmarking URL ${ url }.`;
+					if ( 0 === completeRequests ) {
+						log( formats.error( message ) );
+					} else {
+						log( formats.success( message ) );
+					}
 				} else {
-					log( formats.success( 'Success.' ) );
+					if ( 0 === completeRequests ) {
+						log( formats.error( 'Failure.' ) );
+					} else {
+						log( formats.success( 'Success.' ) );
+					}
 				}
 			}
 		} catch ( err ) {

--- a/cli/lib/cli/args.mjs
+++ b/cli/lib/cli/args.mjs
@@ -42,9 +42,26 @@ export function parseWptTestId( testIdOrUrl ) {
 	return testId;
 }
 
+/**
+ * Collects --url args.
+ *
+ * @param {string} url
+ * @param {string[]} urls
+ * @returns {string[]}
+ */
+export function collectUrlArgs( url, urls ) {
+	return urls.concat( [ url ] );
+}
+
 export async function* getURLs( opt ) {
-	if ( !! opt.url ) {
+	if ( typeof opt.url === 'string' ) {
 		yield opt.url;
+	}
+
+	if ( Array.isArray( opt.url ) ) {
+		for ( const url of opt.url ) {
+			yield url;
+		}
 	}
 
 	if ( !! opt.file ) {
@@ -62,7 +79,7 @@ export async function* getURLs( opt ) {
 }
 
 export function shouldLogURLProgress( opt ) {
-	return ! opt.url && !! opt.file;
+	return ( Array.isArray( opt.url ) && opt.url.length > 1 ) || !! opt.url;
 }
 
 export function shouldLogIterationsProgress( opt ) {

--- a/cli/lib/cli/args.mjs
+++ b/cli/lib/cli/args.mjs
@@ -45,9 +45,9 @@ export function parseWptTestId( testIdOrUrl ) {
 /**
  * Collects --url args.
  *
- * @param {string} url
+ * @param {string}   url
  * @param {string[]} urls
- * @returns {string[]}
+ * @return {string[]} URLs.
  */
 export function collectUrlArgs( url, urls ) {
 	return urls.concat( [ url ] );

--- a/cli/run.mjs
+++ b/cli/run.mjs
@@ -49,13 +49,29 @@ import {
 const program = new Command();
 
 const withOptions = ( command, options ) => {
-	options.forEach( ( { description, argname, defaults, required } ) => {
-		if ( required ) {
-			command = command.requiredOption( argname, description );
-		} else {
-			command = command.option( argname, description, defaults );
+	options.forEach(
+		( { description, argname, defaults, parseArg, required } ) => {
+			if ( required ) {
+				command = command.requiredOption(
+					argname,
+					description,
+					parseArg,
+					defaults
+				);
+			} else {
+				if ( parseArg ) {
+					command = command.option(
+						argname,
+						description,
+						parseArg,
+						defaults
+					);
+				} else {
+					command = command.option( argname, description, defaults );
+				}
+			}
 		}
-	} );
+	);
 	return command;
 };
 

--- a/cli/run.mjs
+++ b/cli/run.mjs
@@ -58,17 +58,15 @@ const withOptions = ( command, options ) => {
 					parseArg,
 					defaults
 				);
+			} else if ( parseArg ) {
+				command = command.option(
+					argname,
+					description,
+					parseArg,
+					defaults
+				);
 			} else {
-				if ( parseArg ) {
-					command = command.option(
-						argname,
-						description,
-						parseArg,
-						defaults
-					);
-				} else {
-					command = command.option( argname, description, defaults );
-				}
+				command = command.option( argname, description, defaults );
 			}
 		}
 	);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
         "@wordpress/scripts": "^30.8.1",
         "autocannon": "^7.15.0",
         "chalk": "^5.3.0",
-        "commander": "^12.1.0",
+        "commander": "^14.0.0",
         "csv-stringify": "^6.5.1",
         "lodash-es": "4.17.21",
         "markdown-table": "^3.0.4",
@@ -7425,13 +7425,13 @@
       }
     },
     "node_modules/commander": {
-      "version": "12.1.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
-      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-14.0.0.tgz",
+      "integrity": "sha512-2uM9rYjPvyq39NwLRqaiLtWHyDC1FvryJDa2ATTVims5YAS4PupsEQsDvP14FqhFr0P49CYDugi59xaxJlTXRA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/comment-parser": {
@@ -10608,6 +10608,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/find-process/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/find-process/node_modules/eslint": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@wordpress/scripts": "^30.8.1",
     "autocannon": "^7.15.0",
     "chalk": "^5.3.0",
-    "commander": "^12.1.0",
+    "commander": "^14.0.0",
     "csv-stringify": "^6.5.1",
     "lodash-es": "4.17.21",
     "markdown-table": "^3.0.4",


### PR DESCRIPTION
I'm almost always benchmarking multiple URLs and it's annoying to have to create a file to add so that I can supply those multiple URLs via the `--file` arg. So this PR eliminates the need for a separate URLs file by allowing multiple URLs to be supplied by repeating the `--url` argument.

For example:

```bash
npm run research -- benchmark-web-vitals --number=10 --output="md" --network-conditions="broadband" \
  --url "http://localhost:10008/bison/?disable_print_script_modules_in_footer&disable_script_fetchpriority_low" \
  --url "http://localhost:10008/bison/?disable_print_script_modules_in_footer" \
  --url "http://localhost:10008/bison/?disable_script_fetchpriority_low" \
  --url http://localhost:10008/bison/
```

This involves the usage of the `parseArgs` parameter in the commander npm package, which this PR also updates to v14 from v12. (667d34514c9f74c41af2e373ca641c8e4a209f7b)

Additional changes in this PR:

1. When all benchmark requests fail for a given URL, show an error progress message rather than a success one. (3a57abcc81b7a8303cc5c4e18c02b0d6bf1cbc9d)
2. When a network priming request fails, log an error and ensure the browser instance is closed to prevent the node process from continuing indefinitely. (90486f5224a341d4809c629315c8370cf0f968cd)
3. Prevent logging `...` immediately after logging the URL so that it isn't linkified in the terminal. (462f7a94ae1585bf362b1f3ae317f07e087b78cc)