### PR TITLE
Try: Add Firefox support to benchmark-web-vitals

### DIFF
--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -651,9 +651,7 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 							 *
 							 * Click off screen to prevent clicking a link by accident and navigating away.
 							 */
-							await page.click( 'body', {
-								offset: { x: 0, y: 0 },
-							} );
+							await page.mouse.click( 0, 0 );
 							// Get the metric value from the global.
 							const metric =
 								/** @type {number} */ await page.evaluate(

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -646,7 +646,7 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 							 * Click off screen to prevent clicking a link by accident and navigating away.
 							 */
 							await page.click( 'body', {
-								offset: { x: -500, y: -500 },
+								offset: { x: 0, y: 0 },
 							} );
 							// Get the metric value from the global.
 							const metric =

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -657,8 +657,9 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 							value.results.push( metric );
 						}
 					)
-				).catch( () => {
-					/* Ignore errors. */
+				).catch( ( err ) => {
+					// TODO: Why not just throw this error, or rather not catch it in order to skip to the next iteration.
+					log( formats.error( `Error: ${ err.message }.` ) );
 				} );
 			}
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -254,7 +254,21 @@ function getParamsFromOptions( opt ) {
 		}
 	}
 
+	if ( [ 'chrome', 'firefox' ].includes( opt.browser ) ) {
+		params.browser = opt.browser;
+	} else {
+		throw new Error(
+			`Unrecognized browser: ${ opt.browser }. Must be 'chrome' or 'firefox'.`
+		);
+	}
+
 	if ( opt.networkConditions ) {
+		if ( params.browser === 'firefox' ) {
+			throw new Error(
+				'Network emulation is not currently available in Firefox.'
+			);
+		}
+
 		if ( 'broadband' === opt.networkConditions ) {
 			/**
 			 * Network conditions used for desktop in Lighthouse/PSI.
@@ -287,14 +301,6 @@ function getParamsFromOptions( opt ) {
 			);
 		}
 		params.emulateDevice = KnownDevices[ opt.emulateDevice ];
-	}
-
-	if ( [ 'chrome', 'firefox' ].includes( opt.browser ) ) {
-		params.browser = opt.browser;
-	} else {
-		throw new Error(
-			`Unrecognized browser: ${ opt.browser }. Must be 'chrome' or 'firefox'.`
-		);
 	}
 
 	if ( opt.windowViewport ) {
@@ -587,7 +593,7 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 				await page.emulateCPUThrottling( params.cpuThrottleFactor );
 			}
 
-			if ( 'firefox' !== params.browser && params.networkConditions ) {
+			if ( params.networkConditions ) {
 				await page.emulateNetworkConditions( params.networkConditions );
 			}
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -245,21 +245,26 @@ function getParamsFromOptions( opt ) {
 		);
 	}
 
-	if ( opt.throttleCpu ) {
-		params.cpuThrottleFactor = parseFloat( opt.throttleCpu );
-		if ( isNaN( params.cpuThrottleFactor ) ) {
-			throw new Error(
-				`Supplied CPU throttle factor "${ opt.throttleCpu }" is not a number.`
-			);
-		}
-	}
-
 	if ( [ 'chrome', 'firefox' ].includes( opt.browser ) ) {
 		params.browser = opt.browser;
 	} else {
 		throw new Error(
 			`Unrecognized browser: ${ opt.browser }. Must be 'chrome' or 'firefox'.`
 		);
+	}
+
+	if ( opt.throttleCpu ) {
+		if ( params.browser === 'firefox' ) {
+			throw new Error(
+				'CPU throttling is not currently available in Firefox..'
+			);
+		}
+		params.cpuThrottleFactor = parseFloat( opt.throttleCpu );
+		if ( isNaN( params.cpuThrottleFactor ) ) {
+			throw new Error(
+				`Supplied CPU throttle factor "${ opt.throttleCpu }" is not a number.`
+			);
+		}
 	}
 
 	if ( opt.networkConditions ) {

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -28,6 +28,7 @@ import round from 'lodash-es/round.js';
 /* eslint-disable jsdoc/valid-types */
 /** @typedef {import("puppeteer").NetworkConditions} NetworkConditions */
 /** @typedef {import("puppeteer").Browser} Browser */
+/** @typedef {import("puppeteer").SupportedBrowser} SupportedBrowser */
 /** @typedef {keyof typeof PredefinedNetworkConditions} NetworkConditionName */
 /** @typedef {import("puppeteer").Device} Device */
 /** @typedef {keyof typeof KnownDevices} KnownDeviceName */
@@ -122,6 +123,12 @@ export const options = [
 			'Enable a specific device by name, for example "Moto G4" or "iPad"',
 	},
 	{
+		argname: '-b, --browser <browser>',
+		description:
+			'Use a specific browser for benchmarking. Can be either "chrome" or "firefox". Defaults to "chrome".',
+		defaults: 'chrome',
+	},
+	{
 		argname: '-w, --window-viewport <dimensions>',
 		description:
 			'Open page with the supplied viewport dimensions such as "mobile" (an alias for "412x823") or "desktop" (an alias for "1350x940"), defaults to "960x700" if no specific device is being emulated',
@@ -151,6 +158,7 @@ export const options = [
  * @property {?number}             cpuThrottleFactor  - See above.
  * @property {?NetworkConditions}  networkConditions  - See above.
  * @property {?Device}             emulateDevice      - See above.
+ * @property {SupportedBrowser}    browser            - See above.
  * @property {?ViewportDimensions} windowViewport     - See above.
  * @property {?number}             pauseDuration      - See above.
  * @property {boolean}             skipNetworkPriming - See above.
@@ -179,6 +187,7 @@ export const options = [
  * @param {?string}       opt.throttleCpu
  * @param {?string}       opt.networkConditions
  * @param {?string}       opt.emulateDevice
+ * @param {string}        opt.browser
  * @param {?string}       opt.windowViewport
  * @param {?string}       opt.pauseDuration
  * @param {boolean}       opt.skipNetworkPriming
@@ -204,6 +213,7 @@ function getParamsFromOptions( opt ) {
 		cpuThrottleFactor: null,
 		networkConditions: null,
 		emulateDevice: null,
+		browser: null,
 		pauseDuration: null,
 		skipNetworkPriming: Boolean( opt.skipNetworkPriming ),
 		windowViewport: ! opt.emulateDevice
@@ -277,6 +287,14 @@ function getParamsFromOptions( opt ) {
 			);
 		}
 		params.emulateDevice = KnownDevices[ opt.emulateDevice ];
+	}
+
+	if ( [ 'chrome', 'firefox' ].includes( opt.browser ) ) {
+		params.browser = opt.browser;
+	} else {
+		throw new Error(
+			`Unrecognized browser: ${ opt.browser }. Must be 'chrome' or 'firefox'.`
+		);
 	}
 
 	if ( opt.windowViewport ) {
@@ -519,7 +537,7 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 	// Prime the network connections so that the initial DNS lookup in the operating system does not negatively impact the initial TTFB metric.
 	if ( ! params.skipNetworkPriming ) {
 		try {
-			browser = await launchBrowser();
+			browser = await launchBrowser( params.browser );
 			if ( logProgress ) {
 				log( `Priming network...` );
 			}
@@ -555,19 +573,21 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 
 	for ( let requestNum = 0; requestNum < params.amount; requestNum++ ) {
 		try {
-			browser = await launchBrowser();
+			browser = await launchBrowser( params.browser );
 			if ( logProgress ) {
 				logPartial(
 					`Benchmarking ${ requestNum + 1 } / ${ params.amount }...`
 				);
 			}
 			const page = await browser.newPage();
-			await page.setBypassCSP( true ); // Bypass CSP so the web vitals script tag can be injected below.
+			if ( 'firefox' !== params.browser ) {
+				await page.setBypassCSP( true ); // Bypass CSP so the web vitals script tag can be injected below.
+			}
 			if ( params.cpuThrottleFactor ) {
 				await page.emulateCPUThrottling( params.cpuThrottleFactor );
 			}
 
-			if ( params.networkConditions ) {
+			if ( 'firefox' !== params.browser && params.networkConditions ) {
 				await page.emulateNetworkConditions( params.networkConditions );
 			}
 
@@ -894,10 +914,12 @@ function outputResults( opt, results ) {
 /**
  * Launches headless browser with cache disabled.
  *
+ * @param {SupportedBrowser} browser - Browser type.
  * @return {Promise<Browser>} Browser.
  */
-async function launchBrowser() {
+async function launchBrowser( browser ) {
 	return puppeteer.launch( {
+		browser,
 		headless: true,
 		args: [ '--disable-cache' ],
 	} );

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
       "name": "wpp-research",
       "license": "Apache-2.0",
       "devDependencies": {
+        "@puppeteer/browsers": "^2.10.5",
         "@wordpress/scripts": "^30.8.1",
         "autocannon": "^7.15.0",
         "chalk": "^5.3.0",
@@ -3627,19 +3628,18 @@
       "license": "MIT"
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
-      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+      "version": "2.10.5",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.10.5.tgz",
+      "integrity": "sha512-eifa0o+i8dERnngJwKrfp3dEq7ia5XFyoqB17S4gK8GhsQE4/P8nxOfQSE0zQHxzzLo/cmF+7+ywEQ7wK7Fb+w==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^4.4.0",
+        "debug": "^4.4.1",
         "extract-zip": "^2.0.1",
         "progress": "^2.0.3",
         "proxy-agent": "^6.5.0",
-        "semver": "^7.6.3",
-        "tar-fs": "^3.0.6",
-        "unbzip2-stream": "^1.4.3",
+        "semver": "^7.7.2",
+        "tar-fs": "^3.0.8",
         "yargs": "^17.7.2"
       },
       "bin": {
@@ -3650,9 +3650,9 @@
       }
     },
     "node_modules/@puppeteer/browsers/node_modules/semver": {
-      "version": "7.6.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-      "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -8267,9 +8267,9 @@
       "license": "MIT"
     },
     "node_modules/debug": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -17631,12 +17631,71 @@
         "node": ">=18"
       }
     },
+    "node_modules/puppeteer-core/node_modules/@puppeteer/browsers": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/puppeteer-core/node_modules/devtools-protocol": {
       "version": "0.0.1367902",
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1367902.tgz",
       "integrity": "sha512-XxtPuC3PGakY6PD7dG66/o8KwJ/LkH2/EKe19Dcw58w53dv4/vSQEkn/SzuyhHE2q4zPgCkxQBxus3VV4ql+Pg==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/puppeteer-core/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/puppeteer/node_modules/@puppeteer/browsers": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.6.1.tgz",
+      "integrity": "sha512-aBSREisdsGH890S2rQqK82qmQYU3uFpSH8wcZWHgHzl3LfzsxAKbLNiAG9mO8v1Y0UICBeClICxPJvyr0rcuxg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "extract-zip": "^2.0.1",
+        "progress": "^2.0.3",
+        "proxy-agent": "^6.5.0",
+        "semver": "^7.6.3",
+        "tar-fs": "^3.0.6",
+        "unbzip2-stream": "^1.4.3",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "browsers": "lib/cjs/main-cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/puppeteer/node_modules/argparse": {
       "version": "2.0.1",
@@ -17690,6 +17749,19 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/puppeteer/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/pure-rand": {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "node": ">= 18"
   },
   "devDependencies": {
+    "@puppeteer/browsers": "^2.10.5",
     "@wordpress/scripts": "^30.8.1",
     "autocannon": "^7.15.0",
     "chalk": "^5.3.0",


### PR DESCRIPTION
After doing `npm install`, do:

```bash
npx puppeteer browsers install firefox
```

You can then specify that you want to benchmark with Firefox by passing `firefox` to the new `--browser` (`-b`) argument.

Note that network emulation and CPU throttling are [not currently supported](https://pptr.dev/webdriver-bidi#puppeteer-features-not-supported-over-webdriver-bidi). Also, bypassing CSP is not supported so injecting the web-vitals.js script may not work if attempting to benchmark a site which is using a Content Security Policy.

# Chrome

```bash
npm run research -- benchmark-web-vitals -u https://example.org/ -o md -b chrome
```

| URL               | https://example.org/ |
| :---------------- | -------------------: |
| Success Rate      |                 100% |
| FCP (median)      |                211.3 |
| LCP (median)      |                211.3 |
| TTFB (median)     |                181.4 |
| LCP-TTFB (median) |                 29.9 |

# Firefox

```bash
npm run research -- benchmark-web-vitals -u https://example.org/ -o md -b firefox
```

| URL               | https://example.org/ |
| :---------------- | -------------------: |
| Success Rate      |                 100% |
| FCP (median)      |                  339 |
| LCP (median)      |                  339 |
| TTFB (median)     |                  282 |
| LCP-TTFB (median) |                   57 |

