### PR TITLE
Add TTLB (Time To Last Byte) metric

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -159,7 +159,7 @@ Loads the provided URLs in a headless browser several times to measure median We
 * `--number` (`-n`): Total number of requests to send.
 * `--file` (`-f`): File with URLs (one URL per line) to run benchmark tests for.
 * `--diff` (`-d`): Add diffs in terms of milliseconds and percentages when two URLs are provided via `--file`.
-* `--metrics` (`-m`): Which metrics to include; by default these are "FCP", "LCP", "TTFB" and "LCP-TTFB".
+* `--metrics` (`-m`): Which metrics to include; by default these are "FCP", "LCP", "TTFB", "TTLB", and "LCP-TTFB".
 * `--output` (`-o`): The output format: Either "table", "csv", or "md".
 * `--show-percentiles` (`-p`): Whether to show more granular percentiles instead of only the median.
 * `--throttle-cpu` (`-t`): Enable CPU throttling to emulate slow CPUs.

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -91,7 +91,7 @@ export const options = [
 	{
 		argname: '-m, --metrics <metrics...>',
 		description:
-			'Which metrics to include; by default these are "FCP", "LCP", "TTFB", "TTLB", "LCP-TTFB", and "TTLB-TTFB".',
+			'Which metrics to include; by default these are "FCP", "LCP", "TTFB", "TTLB", and "LCP-TTFB".',
 	},
 	{
 		argname: '-o, --output <output>',
@@ -197,7 +197,7 @@ function getParamsFromOptions( opt ) {
 		metrics:
 			opt.metrics && opt.metrics.length
 				? opt.metrics
-				: [ 'FCP', 'LCP', 'TTFB', 'TTLB', 'LCP-TTFB', 'TTLB-TTFB' ],
+				: [ 'FCP', 'LCP', 'TTFB', 'TTLB', 'LCP-TTFB' ],
 		output: opt.output,
 		showPercentiles: Boolean( opt.showPercentiles ),
 		showVariance: Boolean( opt.showVariance ),
@@ -354,11 +354,6 @@ function getMetricsDefinition( metrics ) {
 		'LCP-TTFB': {
 			type: 'aggregate',
 			add: [ 'LCP' ],
-			subtract: [ 'TTFB' ],
-		},
-		'TTLB-TTFB': {
-			type: 'aggregate',
-			add: [ 'TTLB' ],
 			subtract: [ 'TTFB' ],
 		},
 	};


### PR DESCRIPTION
Something I've been missing in the `benchmark-web-vitals` output is the Time to Last Byte (TTLB). This is important for measuring streaming responses versus those which are output-buffered.

I was surprised to find Gemini Code Assist seemed to get this right with the first shot! Prompt:

> In addition to capturing the TTFB, I want this to also include the time to last byte (TTLB) to include in the resulting metrics.

