### PR TITLE
Add `--wait-until` arg to `benchmark-web-vitals`

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -168,6 +168,7 @@ Loads the provided URLs in a headless browser several times to measure median We
 * `--window-viewport` (`-w`): Specify the viewport window size, like "mobile" (an alias for "412x823") or "desktop" (an alias for "1350x940"). Defaults to "960x700" if no device is being emulated.
 * `--pause-duration`: Specify the number of milliseconds to pause between making requests in order to give the server a chance to catch its breath. This is to prevent CPU from getting increasingly taxed which would progressively reflect poorly on TTFB. It's also provided as an option to be a good netizen when benchmarking a site in the field since the `rnd` query parameter will usually bust page caches.
 * `--skip-network-priming`: Skip priming the network before making an initial request with metric collection. By default, an initial request is made to a benchmarked URL without collecting any metrics. This is to ensure that the DNS lookups have been cached in the operating system so that the TTFB for the initial request won't be slower than the rest.
+* `--wait-until`: Specify the [lifecycle event](https://pptr.dev/api/puppeteer.puppeteerlifecycleevent)(s) at which the URL is considered loaded. May be "domcontentloaded", "load", "networkidle0", or "networkidle2". Multiple events may be supplied by repeating the argument. Default "networkidle2".
 
 #### Examples
 

--- a/cli/commands/benchmark-server-timing.mjs
+++ b/cli/commands/benchmark-server-timing.mjs
@@ -26,7 +26,7 @@ import round from 'lodash-es/round.js';
  * Internal dependencies
  */
 import {
-	collectUrlArgs,
+	collectArgs,
 	getURLs,
 	shouldLogURLProgress,
 } from '../lib/cli/args.mjs';
@@ -56,7 +56,7 @@ export const options = [
 		description:
 			'URL to run benchmark tests for, where multiple URLs can be supplied by repeating the argument',
 		defaults: [],
-		parseArg: collectUrlArgs,
+		parseArg: collectArgs,
 	},
 	{
 		argname: '-c, --concurrency <concurrency>',

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -327,10 +327,19 @@ function getParamsFromOptions( opt ) {
 		params.pauseDuration = pauseDuration;
 	}
 
-	const validLifecycleEvents = [ 'load', 'domcontentloaded', 'networkidle0', 'networkidle2' ];
+	const validLifecycleEvents = [
+		'load',
+		'domcontentloaded',
+		'networkidle0',
+		'networkidle2',
+	];
 	for ( const waitUntil of opt.waitUntil ) {
 		if ( ! validLifecycleEvents.includes( waitUntil ) ) {
-			throw new Error( `Unexpected value '${ waitUntil }' for --wait-until. Expected one or more of: ${ validLifecycleEvents.join( ', ' ) }` );
+			throw new Error(
+				`Unexpected value '${ waitUntil }' for --wait-until. Expected one or more of: ${ validLifecycleEvents.join(
+					', '
+				) }`
+			);
 		}
 	}
 

--- a/cli/commands/benchmark-web-vitals.mjs
+++ b/cli/commands/benchmark-web-vitals.mjs
@@ -30,6 +30,7 @@ import round from 'lodash-es/round.js';
 /** @typedef {import("puppeteer").Browser} Browser */
 /** @typedef {keyof typeof PredefinedNetworkConditions} NetworkConditionName */
 /** @typedef {import("puppeteer").Device} Device */
+/** @typedef {import("puppeteer").PuppeteerLifeCycleEvent} LifeCycleEvent */
 /** @typedef {keyof typeof KnownDevices} KnownDeviceName */
 
 /* eslint-enable jsdoc/valid-types */
@@ -41,7 +42,7 @@ import round from 'lodash-es/round.js';
  */
 import {
 	getURLs,
-	collectUrlArgs,
+	collectArgs,
 	shouldLogURLProgress,
 	shouldLogIterationsProgress,
 } from '../lib/cli/args.mjs';
@@ -71,7 +72,7 @@ export const options = [
 		description:
 			'URL to run benchmark tests for, where multiple URLs can be supplied by repeating the argument',
 		defaults: [],
-		parseArg: collectUrlArgs,
+		parseArg: collectArgs,
 	},
 	{
 		argname: '-n, --number <number>',
@@ -136,6 +137,13 @@ export const options = [
 		description:
 			'Whether to skip making an initial network-priming request to the URL before the requests to collect metrics.',
 	},
+	{
+		argname: '--wait-until <lifecycleEvent>',
+		description:
+			'Tells Puppeteer how long to wait before considering the page to be loaded. May be one "load", "domcontentloaded", "networkidle0", and/or "networkidle2". Default "networkidle0". Multiple event strings may be supplied by repeating the argument.',
+		defaults: [ 'networkidle0' ],
+		parseArg: collectArgs,
+	},
 ];
 
 /**
@@ -154,6 +162,7 @@ export const options = [
  * @property {?ViewportDimensions} windowViewport     - See above.
  * @property {?number}             pauseDuration      - See above.
  * @property {boolean}             skipNetworkPriming - See above.
+ * @property {LifeCycleEvent[]}    waitUntil          - See above.
  */
 
 /**
@@ -182,6 +191,7 @@ export const options = [
  * @param {?string}       opt.windowViewport
  * @param {?string}       opt.pauseDuration
  * @param {boolean}       opt.skipNetworkPriming
+ * @param {string[]}      opt.waitUntil
  * @return {Params} Parameters.
  */
 function getParamsFromOptions( opt ) {
@@ -209,6 +219,7 @@ function getParamsFromOptions( opt ) {
 		windowViewport: ! opt.emulateDevice
 			? { width: 960, height: 700 }
 			: null, // Viewport similar to @wordpress/e2e-test-utils 'large' configuration.
+		waitUntil: opt.waitUntil,
 	};
 
 	if ( isNaN( params.amount ) ) {
@@ -314,6 +325,13 @@ function getParamsFromOptions( opt ) {
 			);
 		}
 		params.pauseDuration = pauseDuration;
+	}
+
+	const validLifecycleEvents = [ 'load', 'domcontentloaded', 'networkidle0', 'networkidle2' ];
+	for ( const waitUntil of opt.waitUntil ) {
+		if ( ! validLifecycleEvents.includes( waitUntil ) ) {
+			throw new Error( `Unexpected value '${ waitUntil }' for --wait-until. Expected one or more of: ${ validLifecycleEvents.join( ', ' ) }` );
+		}
 	}
 
 	return params;
@@ -596,7 +614,7 @@ async function benchmarkURL( url, metricsDefinition, params, logProgress ) {
 			}
 
 			const response = await page.goto( urlObj.toString(), {
-				waitUntil: 'networkidle0',
+				waitUntil: params.waitUntil,
 			} );
 			if ( scriptTag ) {
 				await page.addScriptTag( {

--- a/cli/lib/cli/args.mjs
+++ b/cli/lib/cli/args.mjs
@@ -43,14 +43,14 @@ export function parseWptTestId( testIdOrUrl ) {
 }
 
 /**
- * Collects --url args.
+ * Collects args.
  *
- * @param {string}   url
- * @param {string[]} urls
- * @return {string[]} URLs.
+ * @param {string}   arg
+ * @param {string[]} args
+ * @return {string[]} Args.
  */
-export function collectUrlArgs( url, urls ) {
-	return urls.concat( [ url ] );
+export function collectArgs(arg, args ) {
+	return args.concat( [ arg ] );
 }
 
 export async function* getURLs( opt ) {

--- a/cli/lib/cli/args.mjs
+++ b/cli/lib/cli/args.mjs
@@ -49,7 +49,7 @@ export function parseWptTestId( testIdOrUrl ) {
  * @param {string[]} args
  * @return {string[]} Args.
  */
-export function collectArgs(arg, args ) {
+export function collectArgs( arg, args ) {
 	return args.concat( [ arg ] );
 }
 


### PR DESCRIPTION
By default `benchmark-web-vitals` waits until the `networkidle0` lifecycle event, which metrics won't be collected until there are zero requests for 500 ms. This can cause metrics to take an incredibly long time to collect, for example when the theme unit test data been imported and there is a Video block and social media embeds somewhere outside of the viewport. To be able to collect metrics faster, it should be possible to customize the lifecycle event(s) at which the page is considered loaded. The [`waitUntil` function](https://pptr.dev/api/puppeteer.waitforoptions) allows for one or more lifecycle events to be supplied. This extends `benchmark-web-vitals` to add a `--wait-until` arg.